### PR TITLE
处理特殊效果->个人主页下吸顶效果bug

### DIFF
--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView-Swift/JXPagingView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView-Swift/JXPagingView.swift
@@ -219,6 +219,7 @@ open class JXPagingView: UIView {
 
     /// 外部传入的listView，当其内部的scrollView滚动时，需要调用该方法
     func listViewDidScroll(scrollView: UIScrollView) {
+        currentScrollingListView = scrollView
         preferredProcessListViewDidScroll(scrollView: scrollView)
     }
 }


### PR DESCRIPTION
bug1:
个人主页吸顶效果下，横向滚动时，生成新的JXPagingViewListViewDelegate回调不执行，即新的列表实例没有进行初始化。
处理文件及对应的函数:
JXPagingListContainerView文件下的scrolling、scrollViewDidScroll、listDidAppearOrDisappear函数

bug2:
垂直滚动时，外层容器的scrollView与子列表中的scrollView在吸顶滚动时，存在偏移量突变问题
处理文件及对应的函数:
JXPagingView文件下的listViewDidScroll函数，将currentScrollingListView更新为当前子列表中的scrollView
