### PR TITLE
feat: listContainerView添加清理单个list功能

### DIFF
--- a/Sources/Common/JXSegmentedListContainerView.swift
+++ b/Sources/Common/JXSegmentedListContainerView.swift
@@ -252,6 +252,27 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         listDidAppear(at: currentIndex)
     }
 
+    open func invalidateList(at index: Int) {
+        guard let dataSource = dataSource, let list = validListDict[index] else { return }
+
+        if let listVC = list as? UIViewController {
+            listVC.removeFromParent()
+        }
+        list.listView().removeFromSuperview()
+        validListDict.removeValue(forKey: index)
+
+        if type == .scrollView {
+            scrollView.contentSize = CGSize(width: scrollView.bounds.size.width*CGFloat(dataSource.numberOfLists(in: self)), height: scrollView.bounds.size.height)
+        } else {
+            collectionView.reloadData()
+        }
+
+        if currentIndex == index {
+            listWillAppear(at: currentIndex)
+            listDidAppear(at: currentIndex)
+        }
+    }
+
     //MARK: - Private
     func initListIfNeeded(at index: Int) {
         guard let dataSource = dataSource else { return }

--- a/Sources/Core/JXSegmentedView.swift
+++ b/Sources/Core/JXSegmentedView.swift
@@ -28,6 +28,11 @@ public protocol JXSegmentedViewListContainer {
     func contentScrollView() -> UIScrollView
     func reloadData()
     func didClickSelectedItem(at index: Int)
+    func invalidateList(at index: Int)
+}
+
+extension JXSegmentedViewListContainer {
+    public func invalidateList(at index: Int) {}
 }
 
 public protocol JXSegmentedViewDataSource: AnyObject {


### PR DESCRIPTION
在单个列表占用内存较大的场景下需要一种及时清理一些list的功能，比如清理旧的或者不再使用的list。目前只有reloadData可以清理list，但是清理的是所有list，很多场景下无法满足需求。