### PR TITLE
fix: 修改 dark mode 下, 颜色计算问题

### DIFF
--- a/JXSegmentedView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JXSegmentedView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Common/JXSegmentedViewTool.swift
+++ b/Sources/Common/JXSegmentedViewTool.swift
@@ -58,3 +58,19 @@ public class JXSegmentedViewTool {
         return resultColors
     }
 }
+
+extension JXSegmentedViewTool {
+    public static func interpolateThemeColor(from: UIColor, to: UIColor, percent: CGFloat) -> UIColor {
+        
+        if #available(iOS 13.0, *) {
+            return UIColor { (traitCollection) -> UIColor in
+                let resolvedFrom = from.resolvedColor(with: traitCollection)
+                let resolvedTo = to.resolvedColor(with: traitCollection)
+                return interpolateColor(from: resolvedFrom, to: resolvedTo, percent: percent)
+            }
+            
+        } else {
+            return interpolateColor(from: from, to: to, percent: percent)
+        }
+    }
+}

--- a/Sources/Title/JXSegmentedTitleCell.swift
+++ b/Sources/Title/JXSegmentedTitleCell.swift
@@ -188,10 +188,10 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
         return {[weak self] (percent) in
             if itemModel.isSelected {
                 //将要选中，textColor从titleNormalColor到titleSelectedColor插值渐变
-                itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: itemModel.titleNormalColor, to: itemModel.titleSelectedColor, percent: percent)
+                itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateThemeColor(from: itemModel.titleNormalColor, to: itemModel.titleSelectedColor, percent: percent)
             }else {
                 //将要取消选中，textColor从titleSelectedColor到titleNormalColor插值渐变
-                itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: itemModel.titleSelectedColor, to: itemModel.titleNormalColor, percent: percent)
+                itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateThemeColor(from: itemModel.titleSelectedColor, to: itemModel.titleNormalColor, percent: percent)
             }
             self?.titleLabel.textColor = itemModel.titleCurrentColor
         }

--- a/Sources/Title/JXSegmentedTitleDataSource.swift
+++ b/Sources/Title/JXSegmentedTitleDataSource.swift
@@ -135,8 +135,8 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
         }
 
         if isTitleColorGradientEnabled && isItemTransitionEnabled {
-            leftModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: leftModel.titleSelectedColor, to: leftModel.titleNormalColor, percent: percent)
-            rightModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from:rightModel.titleNormalColor , to:rightModel.titleSelectedColor, percent: percent)
+            leftModel.titleCurrentColor = JXSegmentedViewTool.interpolateThemeColor(from: leftModel.titleSelectedColor, to: leftModel.titleNormalColor, percent: percent)
+            rightModel.titleCurrentColor = JXSegmentedViewTool.interpolateThemeColor(from:rightModel.titleNormalColor , to:rightModel.titleSelectedColor, percent: percent)
         }
     }
 


### PR DESCRIPTION
dark mode 下, 需要 `resolvedColor`, 来解决动态颜色问题.
问题出现条件, userInterfaceStyle 是 dark 的时候, 滑动切换, title 颜色会闪一下错误颜色