### PR TITLE
删除Public Protocol上的@objc以修复开启BUILD_LIBRARY_FOR_DISTRIBUTION和iOS13以下版本的兼容问题。

### DIFF
--- a/Example/JXSegmentedViewExample/AppDelegate.swift
+++ b/Example/JXSegmentedViewExample/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -41,6 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/Example/JXSegmentedViewExample/Common/CellCustomizeViewController.swift
+++ b/Example/JXSegmentedViewExample/Common/CellCustomizeViewController.swift
@@ -35,21 +35,21 @@ class CellCustomizeViewController: UITableViewController {
 
         switch itemTitle! {
         case "颜色渐变":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
         case "文字渐变":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleGradientDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
         case "大小缩放":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -58,7 +58,7 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
         case "大小缩放+字体粗细":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -68,7 +68,7 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
         case "大小缩放+点击动画":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -83,8 +83,8 @@ class CellCustomizeViewController: UITableViewController {
 
             vc.segmentedDataSource = dataSource
         case "大小缩放+Cell宽度缩放":
-            //高仿汽车之家
-            //配置数据源
+            // 高仿汽车之家
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -101,7 +101,7 @@ class CellCustomizeViewController: UITableViewController {
 
             vc.segmentedDataSource = dataSource
         case "数字":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedNumberDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
@@ -115,14 +115,14 @@ class CellCustomizeViewController: UITableViewController {
             }
             vc.segmentedDataSource = dataSource
         case "红点":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedDotDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             dataSource.dotStates = dotStates
             vc.segmentedDataSource = dataSource
         case "文字和图片":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleImageDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
@@ -130,13 +130,13 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.isImageZoomEnabled = true
             dataSource.normalImageInfos = ["monkey", "frog", "dog", "pig", "sheep", "chicken", "horse", "cow", "elephant", "dragon"]
             dataSource.loadImageClosure = {(imageView, normalImageInfo) in
-                //如果normalImageInfo传递的是图片的地址，你需要借助SDWebImage等第三方库进行图片加载。
-                //加载bundle内的图片，就用下面的方式，内部默认也采用该方法。
+                // 如果normalImageInfo传递的是图片的地址，你需要借助SDWebImage等第三方库进行图片加载。
+                // 加载bundle内的图片，就用下面的方式，内部默认也采用该方法。
                 imageView.image = UIImage(named: normalImageInfo)
             }
             vc.segmentedDataSource = dataSource
         case "文字或者图片":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleOrImageDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -148,13 +148,13 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.titles = titles
             dataSource.selectedImageInfos = ["monkey", nil, "dog", nil, "sheep", "chicken", "horse", nil, nil, "dragon"]
             dataSource.loadImageClosure = {(imageView, normalImageInfo) in
-                //如果normalImageInfo传递的是图片的地址，你需要借助SDWebImage等第三方库进行图片加载。
-                //加载bundle内的图片，就用下面的方式，内部默认也采用该方法。
+                // 如果normalImageInfo传递的是图片的地址，你需要借助SDWebImage等第三方库进行图片加载。
+                // 加载bundle内的图片，就用下面的方式，内部默认也采用该方法。
                 imageView.image = UIImage(named: normalImageInfo)
             }
             vc.segmentedDataSource = dataSource
         case "多行文字(自己添加换行符)":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -162,7 +162,7 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.titles = ["猴哥\nmonkey", "青蛙王子\nfrog", "旺财\ndot", "粉红猪\npig", "喜羊羊\nsheep", "黄焖鸡\nchicken", "小马哥\nhorse", "牛魔王\ncow", "大象先生\nelepant", "神龙\ndragon"]
             vc.segmentedDataSource = dataSource
         case "多行文字(固定宽度自动换行)":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titleSelectedColor = UIColor.red
@@ -171,15 +171,15 @@ class CellCustomizeViewController: UITableViewController {
             dataSource.titles = ["猴哥 monkey", "青蛙王子 frog", "旺财 dot", "粉红猪 pig", "喜羊羊 sheep", "黄焖鸡 chicken", "小马哥 horse", "牛魔王 cow", "大象先生 elepant", "神龙 dragon"]
             vc.segmentedDataSource = dataSource
         case "多行富文本":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleAttributeDataSource()
             func formatNormal(attriText: NSMutableAttributedString) {
-                attriText.addAttributes([NSAttributedString.Key.foregroundColor : UIColor.blue, NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15)], range: NSRange(location: 0, length: 2))
-                attriText.addAttributes([NSAttributedString.Key.foregroundColor : UIColor.black, NSAttributedString.Key.font : UIFont.systemFont(ofSize: 13)], range: NSRange(location: 2, length: attriText.string.count - 2))
+                attriText.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.blue, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15)], range: NSRange(location: 0, length: 2))
+                attriText.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.black, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 13)], range: NSRange(location: 2, length: attriText.string.count - 2))
             }
             func formatSelected(attriText: NSMutableAttributedString) {
-                attriText.addAttributes([NSAttributedString.Key.foregroundColor : UIColor.red, NSAttributedString.Key.font : UIFont.systemFont(ofSize: 16)], range: NSRange(location: 0, length: 2))
-                attriText.addAttributes([NSAttributedString.Key.foregroundColor : UIColor.black, NSAttributedString.Key.font : UIFont.systemFont(ofSize: 14)], range: NSRange(location: 2, length: attriText.string.count - 2))
+                attriText.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.red, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)], range: NSRange(location: 0, length: 2))
+                attriText.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.black, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14)], range: NSRange(location: 2, length: attriText.string.count - 2))
             }
             let mondayAttriText = NSMutableAttributedString(string: "周一\n1月7号")
             formatNormal(attriText: mondayAttriText)
@@ -194,7 +194,7 @@ class CellCustomizeViewController: UITableViewController {
             formatSelected(attriText: wednesdayAttriText)
             dataSource.selectedAttributedTitles = [mondayAttriText.copy(), tuesdayAttriText.copy(), wednesdayAttriText.copy()] as? [NSAttributedString]
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.indicatorHeight = 40
             indicator.indicatorCornerRadius = 5
@@ -207,6 +207,5 @@ class CellCustomizeViewController: UITableViewController {
         }
         navigationController?.pushViewController(vc, animated: true)
     }
-
 
 }

--- a/Example/JXSegmentedViewExample/Common/ContentBaseViewController.swift
+++ b/Example/JXSegmentedViewExample/Common/ContentBaseViewController.swift
@@ -20,8 +20,8 @@ class ContentBaseViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .white
-        
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedView.dataSource = segmentedDataSource
         segmentedView.delegate = self
         view.addSubview(segmentedView)
@@ -44,8 +44,7 @@ class ContentBaseViewController: UIViewController {
         if (segmentedDataSource as? JXSegmentedTitleImageDataSource) != nil {
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: "设置", style: UIBarButtonItem.Style.plain, target: self, action: #selector(didSetingsButtonClicked))
         }
-        
-        
+
         if let _ = segmentedDataSource as? JXSegmentedNumberDataSource {
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: "刷新", style: UIBarButtonItem.Style.plain, target: self, action: #selector(hanldeNumberRefresh))
         }
@@ -54,17 +53,17 @@ class ContentBaseViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        //处于第一个item的时候，才允许屏幕边缘手势返回
+        // 处于第一个item的时候，才允许屏幕边缘手势返回
         navigationController?.interactivePopGestureRecognizer?.isEnabled = (segmentedView.selectedIndex == 0)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        //离开页面的时候，需要恢复屏幕边缘手势，不能影响其他页面
+        // 离开页面的时候，需要恢复屏幕边缘手势，不能影响其他页面
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
@@ -77,9 +76,9 @@ class ContentBaseViewController: UIViewController {
         vc.title = title
         vc.clickedClosure = {[weak self] (type) in
             (self?.segmentedDataSource as? JXSegmentedTitleImageDataSource)?.titleImageType = type
-            //先更新数据源
+            // 先更新数据源
             self?.segmentedDataSource?.reloadData(selectedIndex: self?.segmentedView.selectedIndex ?? 0)
-            //再更新segmentedView
+            // 再更新segmentedView
             self?.segmentedView.reloadData()
         }
         navigationController?.pushViewController(vc, animated: true)
@@ -89,16 +88,15 @@ class ContentBaseViewController: UIViewController {
         for indicaotr in (segmentedView.indicators as! [JXSegmentedIndicatorBaseView]) {
             if indicaotr.indicatorPosition == .bottom {
                 indicaotr.indicatorPosition = .top
-            }else {
+            } else {
                 indicaotr.indicatorPosition = .bottom
             }
         }
         segmentedView.reloadDataWithoutListContainer()
     }
-    
-    //MARK: 数字刷新demo
-    @objc func hanldeNumberRefresh()
-    {
+
+    // MARK: 数字刷新demo
+    @objc func hanldeNumberRefresh() {
         if let _segDataSource = segmentedDataSource as? JXSegmentedNumberDataSource {
             let newNumbers = [223, 12, 435, 332, 0, 32, 98, 0, 99999, 112]
             _segDataSource.numberHeight = 18
@@ -113,9 +111,9 @@ class ContentBaseViewController: UIViewController {
 extension ContentBaseViewController: JXSegmentedViewDelegate {
     func segmentedView(_ segmentedView: JXSegmentedView, didSelectedItemAt index: Int) {
         if let dotDataSource = segmentedDataSource as? JXSegmentedDotDataSource {
-            //先更新数据源的数据
+            // 先更新数据源的数据
             dotDataSource.dotStates[index] = false
-            //再调用reloadItem(at: index)
+            // 再调用reloadItem(at: index)
             segmentedView.reloadItem(at: index)
         }
 
@@ -135,4 +133,3 @@ extension ContentBaseViewController: JXSegmentedListContainerViewDataSource {
         return ListBaseViewController()
     }
 }
-

--- a/Example/JXSegmentedViewExample/Common/IndicatorCustomizeViewController.swift
+++ b/Example/JXSegmentedViewExample/Common/IndicatorCustomizeViewController.swift
@@ -33,95 +33,95 @@ class IndicatorCustomizeViewController: UITableViewController {
 
         switch itemTitle! {
         case "LineView固定长度":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             indicator.indicatorWidth = 20
             vc.segmentedView.indicators = [indicator]
         case "LineView与Cell同宽":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             vc.segmentedView.indicators = [indicator]
         case "LineView延长style":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             indicator.lineStyle = .lengthen
             vc.segmentedView.indicators = [indicator]
         case "LineView延长+偏移style":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             indicator.lineStyle = .lengthenOffset
             vc.segmentedView.indicators = [indicator]
         case "LineView彩虹":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorRainbowLineView()
             indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             indicator.lineStyle = .lengthenOffset
             indicator.indicatorColors = [.red, .green, .blue, .orange, .purple, .cyan, .gray, .red, .yellow, .blue]
             vc.segmentedView.indicators = [indicator]
         case "TriangleView三角形":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorTriangleView()
             vc.segmentedView.indicators = [indicator]
         case "BallView小红点":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.indicatorHeight = 30
             vc.segmentedView.indicators = [indicator]
         case "BackgroundView椭圆形":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.indicatorHeight = 30
             vc.segmentedView.indicators = [indicator]
         case "BackgroundView椭圆形+阴影":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.indicatorHeight = 30
             indicator.layer.shadowColor = UIColor.red.cgColor
@@ -130,92 +130,92 @@ class IndicatorCustomizeViewController: UITableViewController {
             indicator.layer.shadowOpacity = 0.6
             vc.segmentedView.indicators = [indicator]
         case "BackgroundView遮罩有背景":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = false
             dataSource.isTitleMaskEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.isIndicatorConvertToItemFrameEnabled = true
             indicator.indicatorHeight = 30
             vc.segmentedView.indicators = [indicator]
         case "BackgroundView遮罩无背景":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = false
             dataSource.isTitleMaskEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.alpha = 0
             indicator.isIndicatorConvertToItemFrameEnabled = true
             indicator.indicatorHeight = 30
             vc.segmentedView.indicators = [indicator]
         case "BackgroundView渐变色":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorBackgroundView()
             indicator.clipsToBounds = true
             indicator.indicatorHeight = 30
 //            indicator.indicatorHeight = 3
 //            indicator.indicatorPosition = .bottom
-            //相当于把JXSegmentedIndicatorBackgroundView当做视图容器，你可以在上面添加任何想要的效果
-            //这里的方案主要提供一个可以在指示器视图添加自己视图的思路，如果只是需要渐变色lineView。请参考下面的【GradientLine渐变色】示例，使用JXSegmentedIndicatorGradientLineView类即可。
+            // 相当于把JXSegmentedIndicatorBackgroundView当做视图容器，你可以在上面添加任何想要的效果
+            // 这里的方案主要提供一个可以在指示器视图添加自己视图的思路，如果只是需要渐变色lineView。请参考下面的【GradientLine渐变色】示例，使用JXSegmentedIndicatorGradientLineView类即可。
             let gradientView = JXSegmentedComponetGradientView()
             gradientView.gradientLayer.endPoint = CGPoint(x: 1, y: 0)
             gradientView.gradientLayer.colors = [UIColor(red: 90/255, green: 215/255, blue: 202/255, alpha: 1).cgColor, UIColor(red: 122/255, green: 232/255, blue: 169/255, alpha: 1).cgColor]
-            //设置gradientView布局和JXSegmentedIndicatorBackgroundView一样
+            // 设置gradientView布局和JXSegmentedIndicatorBackgroundView一样
             gradientView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             indicator.addSubview(gradientView)
             vc.segmentedView.indicators = [indicator]
         case "GradientLine渐变色":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorGradientLineView()
             indicator.colors = [UIColor.red, UIColor.green]
             vc.segmentedView.indicators = [indicator]
         case "ImageView底部":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorImageView()
             indicator.image = UIImage(named: "car")
             indicator.indicatorWidth = 24
             indicator.indicatorHeight = 18
             vc.segmentedView.indicators = [indicator]
         case "ImageView背景":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorImageView()
             indicator.indicatorWidth = 50
             indicator.indicatorHeight = 50
             indicator.image = UIImage(named: "light")
             vc.segmentedView.indicators = [indicator]
         case "混合使用":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let lineIndicator = JXSegmentedIndicatorLineView()
             lineIndicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             lineIndicator.lineStyle = .normal
@@ -224,37 +224,37 @@ class IndicatorCustomizeViewController: UITableViewController {
             bgIndicator.indicatorHeight = 30
             vc.segmentedView.indicators = [lineIndicator, bgIndicator]
         case "DotLine点线效果":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorDotLineView()
             vc.segmentedView.indicators = [indicator]
         case "DoubleLine双线效果":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorDoubleLineView()
             vc.segmentedView.indicators = [indicator]
         case "GradientView渐变色":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorGradientView()
 //            indicator.indicatorHeight = 3
 //            indicator.indicatorPosition = .bottom
 
             vc.segmentedView.indicators = [indicator]
         case "指示器宽度跟随内容而不是cell宽度":
-            //配置数据源
+            // 配置数据源
             let dataSource = JXSegmentedTitleDataSource()
             dataSource.isTitleColorGradientEnabled = true
             dataSource.titles = ["很长的第一名", "第二", "普通第三"]
@@ -262,7 +262,7 @@ class IndicatorCustomizeViewController: UITableViewController {
             dataSource.itemSpacing = 0
             dataSource.isTitleZoomEnabled = true
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
             indicator.isIndicatorWidthSameAsItemContent = true

--- a/Example/JXSegmentedViewExample/Common/SpecialCustomizeViewController.swift
+++ b/Example/JXSegmentedViewExample/Common/SpecialCustomizeViewController.swift
@@ -60,7 +60,7 @@ class SpecialCustomizeViewController: UITableViewController {
             dataSource.isItemSpacingAverageEnabled = true
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             vc.segmentedView.indicators = [indicator]
             navigationController?.pushViewController(vc, animated: true)
@@ -72,7 +72,7 @@ class SpecialCustomizeViewController: UITableViewController {
             dataSource.isItemSpacingAverageEnabled = false
             dataSource.titles = titles
             vc.segmentedDataSource = dataSource
-            //配置指示器
+            // 配置指示器
             let indicator = JXSegmentedIndicatorLineView()
             vc.segmentedView.indicators = [indicator]
             navigationController?.pushViewController(vc, animated: true)

--- a/Example/JXSegmentedViewExample/Common/TitleImageSettingViewController.swift
+++ b/Example/JXSegmentedViewExample/Common/TitleImageSettingViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import JXSegmentedView
 
 class TitleImageSettingViewController: UITableViewController {
-    var clickedClosure: ((JXSegmentedTitleImageType) -> ())?
+    var clickedClosure: ((JXSegmentedTitleImageType) -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Example/JXSegmentedViewExample/Custom/MixCell/JXSegmentedMixcellDataSource.swift
+++ b/Example/JXSegmentedViewExample/Custom/MixCell/JXSegmentedMixcellDataSource.swift
@@ -51,31 +51,31 @@ class JXSegmentedMixcellDataSource: JXSegmentedBaseDataSource {
     }
 
     override func preferredSegmentedView(_ segmentedView: JXSegmentedView, widthForItemAt index: Int) -> CGFloat {
-        //根据不同的cell类型返回对应的cell宽度
+        // 根据不同的cell类型返回对应的cell宽度
         var otherWidth: CGFloat = 0
         var title: String?
         var titleNormalFont: UIFont?
         if let itemModel = dataSource[index] as? JXSegmentedTitleItemModel {
             title = itemModel.title
             titleNormalFont = itemModel.titleNormalFont
-        }else if let itemModel = dataSource[index] as? JXSegmentedTitleImageItemModel {
+        } else if let itemModel = dataSource[index] as? JXSegmentedTitleImageItemModel {
             title = itemModel.title
             titleNormalFont = itemModel.titleNormalFont
             otherWidth += itemModel.titleImageSpacing + itemModel.imageSize.width
-        }else if let itemModel = dataSource[index] as? JXSegmentedNumberItemModel {
+        } else if let itemModel = dataSource[index] as? JXSegmentedNumberItemModel {
             title = itemModel.title
             titleNormalFont = itemModel.titleNormalFont
-        }else if let itemModel = dataSource[index] as? JXSegmentedDotItemModel {
+        } else if let itemModel = dataSource[index] as? JXSegmentedDotItemModel {
             title = itemModel.title
             titleNormalFont = itemModel.titleNormalFont
         }
 
-        let textWidth = NSString(string: title!).boundingRect(with: CGSize(width: CGFloat(MAXFLOAT), height: segmentedView.bounds.size.height), options: NSStringDrawingOptions.init(rawValue: NSStringDrawingOptions.usesLineFragmentOrigin.rawValue | NSStringDrawingOptions.usesFontLeading.rawValue), attributes: [NSAttributedString.Key.font : titleNormalFont!], context: nil).size.width
+        let textWidth = NSString(string: title!).boundingRect(with: CGSize(width: CGFloat(MAXFLOAT), height: segmentedView.bounds.size.height), options: NSStringDrawingOptions.init(rawValue: NSStringDrawingOptions.usesLineFragmentOrigin.rawValue | NSStringDrawingOptions.usesFontLeading.rawValue), attributes: [NSAttributedString.Key.font: titleNormalFont!], context: nil).size.width
         let itemWidth = CGFloat(ceilf(Float(textWidth))) + itemWidthIncrement + otherWidth
         return itemWidth
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleCell.self, forCellWithReuseIdentifier: "titleCell")
         segmentedView.collectionView.register(JXSegmentedTitleImageCell.self, forCellWithReuseIdentifier: "titleImageCell")
@@ -84,20 +84,20 @@ class JXSegmentedMixcellDataSource: JXSegmentedBaseDataSource {
     }
 
     override func segmentedView(_ segmentedView: JXSegmentedView, cellForItemAt index: Int) -> JXSegmentedBaseCell {
-        var cell:JXSegmentedBaseCell?
+        var cell: JXSegmentedBaseCell?
         if dataSource[index] is JXSegmentedTitleImageItemModel {
             cell = segmentedView.dequeueReusableCell(withReuseIdentifier: "titleImageCell", at: index)
-        }else if dataSource[index] is JXSegmentedNumberItemModel {
+        } else if dataSource[index] is JXSegmentedNumberItemModel {
             cell = segmentedView.dequeueReusableCell(withReuseIdentifier: "numberCell", at: index)
-        }else if dataSource[index] is JXSegmentedDotItemModel {
+        } else if dataSource[index] is JXSegmentedDotItemModel {
             cell = segmentedView.dequeueReusableCell(withReuseIdentifier: "dotCell", at: index)
-        }else if dataSource[index] is JXSegmentedTitleItemModel {
+        } else if dataSource[index] is JXSegmentedTitleItemModel {
             cell = segmentedView.dequeueReusableCell(withReuseIdentifier: "titleCell", at: index)
         }
         return cell!
     }
 
-    //针对不同的cell处理选中态和未选中态的刷新
+    // 针对不同的cell处理选中态和未选中态的刷新
     override func refreshItemModel(_ segmentedView: JXSegmentedView, currentSelectedItemModel: JXSegmentedBaseItemModel, willSelectedItemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType) {
         super.refreshItemModel(segmentedView, currentSelectedItemModel: currentSelectedItemModel, willSelectedItemModel: willSelectedItemModel, selectedType: selectedType)
 

--- a/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/LoadDataCustomListViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/LoadDataCustomListViewController.swift
@@ -19,14 +19,14 @@ class LoadDataCustomListViewController: UITableViewController {
         super.viewDidLoad()
 
         refreshControl = UIRefreshControl()
-        refreshControl?.attributedTitle = NSAttributedString(string: "Loading...", attributes: [NSAttributedString.Key.foregroundColor : UIColor.black])
+        refreshControl?.attributedTitle = NSAttributedString(string: "Loading...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.black])
         refreshControl?.addTarget(self, action: #selector(headerRefresh), for: .valueChanged)
         tableView.register(PagingListBaseCell.self, forCellReuseIdentifier: "cell")
     }
 
     func loadDataForFirst() {
         if !isDataLoaded {
-            //为什么要手动设置contentoffset：https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins
+            // 为什么要手动设置contentoffset：https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins
             tableView.setContentOffset(CGPoint(x: 0, y: -refreshControl!.bounds.size.height), animated: true)
             headerRefresh()
         }
@@ -54,7 +54,7 @@ class LoadDataCustomListViewController: UITableViewController {
         }
     }
 
-    //MARK: - UITableViewDataSource & UITableViewDelegate
+    // MARK: - UITableViewDataSource & UITableViewDelegate
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return dataSource.count
     }

--- a/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/LoadDataCustomViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/LoadDataCustomViewController.swift
@@ -20,40 +20,40 @@ class LoadDataCustomViewController: UIViewController {
 
         view.backgroundColor = .white
 
-        //1、初始化JXSegmentedView
+        // 1、初始化JXSegmentedView
         segmentedView = JXSegmentedView()
 
-        //2、配置数据源
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+        // 2、配置数据源
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedDataSource = JXSegmentedTitleDataSource()
         segmentedDataSource.isTitleColorGradientEnabled = true
         segmentedView.dataSource = segmentedDataSource
 
-        //3、配置指示器
+        // 3、配置指示器
         let indicator = JXSegmentedIndicatorLineView()
         indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
         indicator.lineStyle = .lengthen
         segmentedView.indicators = [indicator]
 
-        //4、配置JXSegmentedView的属性
+        // 4、配置JXSegmentedView的属性
         segmentedView.delegate = self
         view.addSubview(segmentedView)
 
-        //5、初始化contentScrollView
+        // 5、初始化contentScrollView
         contentScrollView = UIScrollView()
         contentScrollView.isPagingEnabled = true
         contentScrollView.showsVerticalScrollIndicator = false
         contentScrollView.showsHorizontalScrollIndicator = false
         contentScrollView.scrollsToTop = false
         contentScrollView.bounces = false
-        //禁用automaticallyInset
+        // 禁用automaticallyInset
         automaticallyAdjustsScrollViewInsets = false
         if #available(iOS 11.0, *) {
             contentScrollView.contentInsetAdjustmentBehavior = .never
         }
         view.addSubview(contentScrollView)
 
-        //6、将contentScrollView和segmentedView.contentScrollView进行关联
+        // 6、将contentScrollView和segmentedView.contentScrollView进行关联
         segmentedView.contentScrollView = contentScrollView
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "刷新数据", style: UIBarButtonItem.Style.plain, target: self, action: #selector(reloadData))
@@ -77,7 +77,7 @@ class LoadDataCustomViewController: UIViewController {
             vc.naviController = navigationController
             contentScrollView.addSubview(vc.view)
             listVCArray.append(vc)
-            
+
 //            if pagingViewShouldRTLLayout() {
 //                pagingView(horizontalFlipForView: vc.view)
 //            }
@@ -101,7 +101,7 @@ class LoadDataCustomViewController: UIViewController {
 
     func getRandomTitles() -> [String] {
         let titles = ["猴哥", "青蛙王子", "旺财", "粉红猪", "喜羊羊", "黄焖鸡", "小马哥", "牛魔王", "大象先生", "神龙"]
-        //随机title数量，4~n
+        // 随机title数量，4~n
         let randomCount = Int(arc4random()%7 + 4)
         var tempTitles = titles
         var resultTitles = [String]()
@@ -119,4 +119,3 @@ extension LoadDataCustomViewController: JXSegmentedViewDelegate {
         listVCArray[index].loadDataForFirst()
     }
 }
-

--- a/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/UIWindow+JXSafeArea.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/ListCustom/UIWindow+JXSafeArea.swift
@@ -14,7 +14,7 @@ extension UIWindow {
         if #available(iOS 11.0, *) {
             if safeAreaInsets.bottom > 0 {
                 return safeAreaInsets
-            }else {
+            } else {
                 return UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
             }
         }

--- a/Example/JXSegmentedViewExample/Special/LoadData/LoadDataDetailViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/LoadDataDetailViewController.swift
@@ -23,7 +23,7 @@ class LoadDataDetailViewController: UIViewController {
         textLabel.font = UIFont.systemFont(ofSize: 18)
         view.addSubview(textLabel)
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
@@ -31,6 +31,5 @@ class LoadDataDetailViewController: UIViewController {
         textLabel.sizeToFit()
         textLabel.center = view.center
     }
-
 
 }

--- a/Example/JXSegmentedViewExample/Special/LoadData/WithListContainerView/LoadDataListViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/WithListContainerView/LoadDataListViewController.swift
@@ -22,7 +22,7 @@ class LoadDataListViewController: UITableViewController {
         super.viewDidLoad()
 
         refreshControl = UIRefreshControl()
-        refreshControl?.attributedTitle = NSAttributedString(string: "Loading...", attributes: [NSAttributedString.Key.foregroundColor : UIColor.black])
+        refreshControl?.attributedTitle = NSAttributedString(string: "Loading...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.black])
         refreshControl?.addTarget(self, action: #selector(headerRefresh), for: .valueChanged)
         tableView.register(PagingListBaseCell.self, forCellReuseIdentifier: "cell")
 
@@ -65,7 +65,7 @@ class LoadDataListViewController: UITableViewController {
         }
     }
 
-    //MARK: - UITableViewDataSource & UITableViewDelegate
+    // MARK: - UITableViewDataSource & UITableViewDelegate
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return dataSource.count
     }
@@ -89,7 +89,7 @@ extension LoadDataListViewController: JXSegmentedListContainerViewListDelegate {
     }
 
     func listDidAppear() {
-        //因为`JXSegmentedListContainerView`内部通过`UICollectionView`的cell加载列表。当切换tab的时候，之前的列表所在的cell就被回收到缓存池，就会从视图层级树里面被剔除掉，即没有显示出来且不在视图层级里面。这个时候MJRefreshHeader所持有的UIActivityIndicatorView就会被设置hidden。所以需要在列表显示的时候，且isRefreshing==YES的时候，再让UIActivityIndicatorView重新开启动画。
+        // 因为`JXSegmentedListContainerView`内部通过`UICollectionView`的cell加载列表。当切换tab的时候，之前的列表所在的cell就被回收到缓存池，就会从视图层级树里面被剔除掉，即没有显示出来且不在视图层级里面。这个时候MJRefreshHeader所持有的UIActivityIndicatorView就会被设置hidden。所以需要在列表显示的时候，且isRefreshing==YES的时候，再让UIActivityIndicatorView重新开启动画。
 //        if (self.tableView.mj_header.isRefreshing) {
 //            UIActivityIndicatorView *activity = [self.tableView.mj_header valueForKey:@"loadingView"];
 //            [activity startAnimating];

--- a/Example/JXSegmentedViewExample/Special/LoadData/WithListContainerView/LoadDataViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/LoadData/WithListContainerView/LoadDataViewController.swift
@@ -19,30 +19,30 @@ class LoadDataViewController: UIViewController {
 
         view.backgroundColor = .white
 
-        //1、初始化JXSegmentedView
+        // 1、初始化JXSegmentedView
         segmentedView = JXSegmentedView()
 
-        //2、配置数据源
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+        // 2、配置数据源
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedDataSource = JXSegmentedTitleDataSource()
         segmentedDataSource.titles = getRandomTitles()
         segmentedDataSource.isTitleColorGradientEnabled = true
         segmentedView.dataSource = segmentedDataSource
-        
-        //3、配置指示器
+
+        // 3、配置指示器
         let indicator = JXSegmentedIndicatorLineView()
         indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
         indicator.lineStyle = .lengthen
         segmentedView.indicators = [indicator]
 
-        //4、配置JXSegmentedView的属性
+        // 4、配置JXSegmentedView的属性
         view.addSubview(segmentedView)
 
-        //5、初始化JXSegmentedListContainerView
+        // 5、初始化JXSegmentedListContainerView
         listContainerView = JXSegmentedListContainerView(dataSource: self)
         view.addSubview(listContainerView)
 
-        //6、将listContainerView.scrollView和segmentedView.contentScrollView进行关联
+        // 6、将listContainerView.scrollView和segmentedView.contentScrollView进行关联
         segmentedView.listContainer = listContainerView
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "刷新数据", style: UIBarButtonItem.Style.plain, target: self, action: #selector(reloadData))
@@ -63,7 +63,7 @@ class LoadDataViewController: UIViewController {
 
     func getRandomTitles() -> [String] {
         let titles = ["猴哥", "青蛙王子", "旺财", "粉红猪", "喜羊羊", "黄焖鸡", "小马哥", "牛魔王", "大象先生", "神龙"]
-        //随机title数量，4~n
+        // 随机title数量，4~n
         let randomCount = Int(arc4random()%7 + 4)
         var tempTitles = titles
         var resultTitles = [String]()

--- a/Example/JXSegmentedViewExample/Special/NaviItemGesture/NaviItemCustomViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/NaviItemGesture/NaviItemCustomViewController.swift
@@ -20,19 +20,19 @@ class NaviItemCustomViewController: ContentBaseViewController {
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
 
         let titles = ["猴哥", "青蛙王子", "旺财", "粉红猪", "喜羊羊", "黄焖鸡", "小马哥", "牛魔王", "大象先生", "神龙"]
-        //配置数据源
+        // 配置数据源
         let dataSource = JXSegmentedTitleDataSource()
         dataSource.isTitleColorGradientEnabled = true
         dataSource.titles = titles
         segmentedDataSource = dataSource
         segmentedView.dataSource = segmentedDataSource
 
-        //配置指示器
+        // 配置指示器
         let indicator = JXSegmentedIndicatorLineView()
         indicator.indicatorWidth = 20
         segmentedView.indicators = [indicator]
     }
-    
+
     @objc func customBackItemClicked(sender: UIBarButtonItem) {
         navigationController?.popViewController(animated: true)
     }

--- a/Example/JXSegmentedViewExample/Special/Nest/NestChildViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/Nest/NestChildViewController.swift
@@ -21,17 +21,17 @@ class NestChildViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .white
-        
-        //配置数据源
+
+        // 配置数据源
         segmentedDataSource.isTitleColorGradientEnabled = true
         segmentedDataSource.titles = titles
 
-        //配置指示器
+        // 配置指示器
         let indicator = JXSegmentedIndicatorLineView()
         indicator.indicatorWidth = JXSegmentedViewAutomaticDimension
         indicator.lineStyle = .lengthen
 
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedView.dataSource = segmentedDataSource
         segmentedView.indicators = [indicator]
         segmentedView.frame = CGRect(x: 0, y: 0, width: view.bounds.size.width, height: 50)

--- a/Example/JXSegmentedViewExample/Special/Nest/NestViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/Nest/NestViewController.swift
@@ -23,7 +23,7 @@ class NestViewController: UIViewController {
 
         let totalItemWidth: CGFloat = 150
         let titles = ["吃饭🍚", "运动💪"]
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedDataSource.itemWidth = totalItemWidth/CGFloat(titles.count)
         segmentedDataSource.titles = titles
         segmentedDataSource.isTitleMaskEnabled = true
@@ -68,11 +68,9 @@ extension NestViewController: JXSegmentedListContainerViewDataSource {
         let vc = NestChildViewController()
         if index == 0 {
            vc.titles = ["吃鸡🍗", "吃西瓜🍉", "吃热狗🌭"]
-        }else if index == 1 {
+        } else if index == 1 {
             vc.titles = ["高尔夫🏌", "滑雪⛷", "自行车🚴"]
         }
         return vc
     }
 }
-
-

--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingListContainerView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingListContainerView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// 列表容器视图的类型
-///- ScrollView: UIScrollView。优势：没有其他副作用。劣势：实时的视图内存占用相对大一点，因为所有加载之后的列表视图都在视图层级里面。
+/// - ScrollView: UIScrollView。优势：没有其他副作用。劣势：实时的视图内存占用相对大一点，因为所有加载之后的列表视图都在视图层级里面。
 /// - CollectionView: 使用UICollectionView。优势：因为列表被添加到cell上，实时的视图内存占用更少，适合内存要求特别高的场景。劣势：因为cell重用机制的问题，导致列表被移除屏幕外之后，会被放入缓存区，而不存在于视图层级中。如果刚好你的列表使用了下拉刷新视图，在快速切换过程中，就会导致下拉刷新回调不成功的问题。一句话概括：使用CollectionView的时候，就不要让列表使用下拉刷新加载。
 public enum JXPagingListContainerType {
     case scrollView
@@ -31,7 +31,7 @@ public protocol JXPagingViewListViewDelegate {
     /// 当listView内部持有的UIScrollView或UITableView或UICollectionView的代理方法`scrollViewDidScroll`回调时，需要调用该代理方法传入的callback
     ///
     /// - Parameter callback: `scrollViewDidScroll`回调时调用的callback
-    func listViewDidScrollCallback(callback: @escaping (UIScrollView)->())
+    func listViewDidScrollCallback(callback: @escaping (UIScrollView) -> Void)
 
     /// 将要重置listScrollView的contentOffset
     @objc optional func listScrollViewWillResetContentOffset()
@@ -63,7 +63,6 @@ public protocol JXPagingListContainerViewDataSource {
     /// - Returns: 遵从JXPagingViewListViewDelegate协议的实例
     func listContainerView(_ listContainerView: JXPagingListContainerView, initListAt index: Int) -> JXPagingViewListViewDelegate
 
-
     /// 控制能否初始化对应index的列表。有些业务需求，需要在某些情况才允许初始化某些列表，通过通过该代理实现控制。
     @objc optional func listContainerView(_ listContainerView: JXPagingListContainerView, canInitListAt index: Int) -> Bool
 
@@ -90,13 +89,13 @@ open class JXPagingListContainerView: UIView {
         didSet {
             if let containerScrollView = scrollView as? JXPagingListContainerScrollView {
                 containerScrollView.isCategoryNestPagingEnabled = isCategoryNestPagingEnabled
-            }else if let containerScrollView = scrollView as? JXPagingListContainerCollectionView {
+            } else if let containerScrollView = scrollView as? JXPagingListContainerCollectionView {
                 containerScrollView.isCategoryNestPagingEnabled = isCategoryNestPagingEnabled
             }
         }
     }
     /// 已经加载过的列表字典。key是index，value是对应的列表
-    open var validListDict = [Int:JXPagingViewListViewDelegate]()
+    open var validListDict = [Int: JXPagingViewListViewDelegate]()
     /// 滚动切换的时候，滚动距离超过一页的多少百分比，就触发列表的初始化。默认0.01（即列表显示了一点就触发加载）。范围0~1，开区间不包括0和1
     open var initListPercent: CGFloat = 0.01 {
         didSet {
@@ -151,7 +150,7 @@ open class JXPagingListContainerView: UIView {
         if type == .scrollView {
             if let scrollViewClass = dataSource.scrollViewClass?(in: self) as? UIScrollView.Type {
                 scrollView = scrollViewClass.init()
-            }else {
+            } else {
                 scrollView = JXPagingListContainerScrollView.init()
             }
             scrollView.backgroundColor = .clear
@@ -165,14 +164,14 @@ open class JXPagingListContainerView: UIView {
                 scrollView.contentInsetAdjustmentBehavior = .never
             }
             containerVC.view.addSubview(scrollView)
-        }else if type == .collectionView {
+        } else if type == .collectionView {
             let layout = UICollectionViewFlowLayout()
             layout.scrollDirection = .horizontal
             layout.minimumLineSpacing = 0
             layout.minimumInteritemSpacing = 0
             if let collectionViewClass = dataSource.scrollViewClass?(in: self) as? UICollectionView.Type {
                 collectionView = collectionViewClass.init(frame: CGRect.zero, collectionViewLayout: layout)
-            }else {
+            } else {
                 collectionView = JXPagingListContainerCollectionView.init(frame: CGRect.zero, collectionViewLayout: layout)
             }
             collectionView.backgroundColor = .clear
@@ -191,7 +190,7 @@ open class JXPagingListContainerView: UIView {
                 self.collectionView.contentInsetAdjustmentBehavior = .never
             }
             containerVC.view.addSubview(collectionView)
-            //让外部统一访问scrollView
+            // 让外部统一访问scrollView
             scrollView = collectionView
         }
     }
@@ -200,7 +199,7 @@ open class JXPagingListContainerView: UIView {
         super.willMove(toSuperview: newSuperview)
         var next: UIResponder? = newSuperview
         while next != nil {
-            if let vc = next as? UIViewController{
+            if let vc = next as? UIViewController {
                 vc.addChild(containerVC)
                 break
             }
@@ -221,23 +220,23 @@ open class JXPagingListContainerView: UIView {
                     list.listView().frame = CGRect(x: CGFloat(index)*scrollView.bounds.size.width, y: 0, width: scrollView.bounds.size.width, height: scrollView.bounds.size.height)
                 }
                 scrollView.contentOffset = CGPoint(x: CGFloat(currentIndex)*scrollView.bounds.size.width, y: 0)
-            }else {
+            } else {
                 scrollView.frame = bounds
                 scrollView.contentSize = CGSize(width: scrollView.bounds.size.width*CGFloat(dataSource.numberOfLists(in: self)), height: scrollView.bounds.size.height)
             }
-        }else {
+        } else {
             if collectionView.frame == CGRect.zero || collectionView.bounds.size != bounds.size {
                 collectionView.frame = bounds
                 collectionView.collectionViewLayout.invalidateLayout()
                 collectionView.reloadData()
                 collectionView.setContentOffset(CGPoint(x: CGFloat(currentIndex)*collectionView.bounds.size.width, y: 0), animated: false)
-            }else {
+            } else {
                 collectionView.frame = bounds
             }
         }
     }
 
-    //MARK: - JXSegmentedViewListContainer
+    // MARK: - JXSegmentedViewListContainer
 
     public func contentScrollView() -> UIScrollView {
            return scrollView
@@ -275,14 +274,14 @@ open class JXPagingListContainerView: UIView {
         validListDict.removeAll()
         if type == .scrollView {
             scrollView.contentSize = CGSize(width: scrollView.bounds.size.width*CGFloat(dataSource.numberOfLists(in: self)), height: scrollView.bounds.size.height)
-        }else {
+        } else {
             collectionView.reloadData()
         }
         listWillAppear(at: currentIndex)
         listDidAppear(at: currentIndex)
     }
 
-    //MARK: - Private
+    // MARK: - Private
     func initListIfNeeded(at index: Int) {
         guard let dataSource = dataSource else { return }
         if dataSource.listContainerView?(self, canInitListAt: index) == false {
@@ -290,7 +289,7 @@ open class JXPagingListContainerView: UIView {
         }
         var existedList = validListDict[index]
         if existedList != nil {
-            //列表已经创建好了
+            // 列表已经创建好了
             return
         }
         existedList = dataSource.listContainerView(self, initListAt: index)
@@ -325,8 +324,8 @@ open class JXPagingListContainerView: UIView {
             if let vc = existedList as? UIViewController {
                 vc.beginAppearanceTransition(true, animated: false)
             }
-        }else {
-            //当前列表未被创建（页面初始化或通过点击触发的listWillAppear）
+        } else {
+            // 当前列表未被创建（页面初始化或通过点击触发的listWillAppear）
             guard dataSource.listContainerView?(self, canInitListAt: index) != false else {
                 return
             }
@@ -347,7 +346,7 @@ open class JXPagingListContainerView: UIView {
                 if let vc = list as? UIViewController {
                     vc.beginAppearanceTransition(true, animated: false)
                 }
-            }else {
+            } else {
                 let cell = collectionView.cellForItem(at: IndexPath(item: index, section: 0))
                 cell?.contentView.subviews.forEach { $0.removeFromSuperview() }
                 list.listView().frame = cell?.contentView.bounds ?? CGRect.zero
@@ -410,15 +409,15 @@ open class JXPagingListContainerView: UIView {
             let disappearIndex = willDisappearIndex
             let appearIndex = willAppearIndex
             if willAppearIndex > willDisappearIndex {
-                //将要出现的列表在右边
+                // 将要出现的列表在右边
                 if currentIndexPercent >= CGFloat(willAppearIndex) {
                     willDisappearIndex = -1
                     willAppearIndex = -1
                     listDidDisappear(at: disappearIndex)
                     listDidAppear(at: appearIndex)
                 }
-            }else {
-                //将要出现的列表在左边
+            } else {
+                // 将要出现的列表在左边
                 if currentIndexPercent <= CGFloat(willAppearIndex) {
                     willDisappearIndex = -1
                     willAppearIndex = -1
@@ -444,7 +443,7 @@ extension JXPagingListContainerView: UICollectionViewDataSource, UICollectionVie
         if list != nil {
             if list is UIViewController {
                 list?.listView().frame = cell.contentView.bounds
-            }else {
+            } else {
                 list?.listView().frame = cell.bounds
             }
             cell.contentView.addSubview(list!.listView())
@@ -465,19 +464,19 @@ extension JXPagingListContainerView: UICollectionViewDataSource, UICollectionVie
         let maxCount = Int(round(scrollView.contentSize.width/scrollView.bounds.size.width))
         var leftIndex = Int(floor(Double(percent)))
         leftIndex = max(0, min(maxCount - 1, leftIndex))
-        let rightIndex = leftIndex + 1;
+        let rightIndex = leftIndex + 1
         if percent < 0 || rightIndex >= maxCount {
             listDidAppearOrDisappear(scrollView: scrollView)
             return
         }
         let remainderRatio = percent - CGFloat(leftIndex)
         if rightIndex == currentIndex {
-            //当前选中的在右边，用户正在从右边往左边滑动
+            // 当前选中的在右边，用户正在从右边往左边滑动
             if validListDict[leftIndex] == nil && remainderRatio < (1 - initListPercent) {
                 initListIfNeeded(at: leftIndex)
-            }else if validListDict[leftIndex] != nil {
+            } else if validListDict[leftIndex] != nil {
                 if willAppearIndex == -1 {
-                    willAppearIndex = leftIndex;
+                    willAppearIndex = leftIndex
                     listWillAppear(at: willAppearIndex)
                 }
             }
@@ -485,11 +484,11 @@ extension JXPagingListContainerView: UICollectionViewDataSource, UICollectionVie
                 willDisappearIndex = rightIndex
                 listWillDisappear(at: willDisappearIndex)
             }
-        }else {
-            //当前选中的在左边，用户正在从左边往右边滑动
+        } else {
+            // 当前选中的在左边，用户正在从左边往右边滑动
             if validListDict[rightIndex] == nil && remainderRatio > initListPercent {
                 initListIfNeeded(at: rightIndex)
-            }else if validListDict[rightIndex] != nil {
+            } else if validListDict[rightIndex] != nil {
                 if willAppearIndex == -1 {
                     willAppearIndex = rightIndex
                     listWillAppear(at: willAppearIndex)
@@ -504,7 +503,7 @@ extension JXPagingListContainerView: UICollectionViewDataSource, UICollectionVie
     }
 
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        //滑动到一半又取消滑动处理
+        // 滑动到一半又取消滑动处理
         if willAppearIndex != -1 || willDisappearIndex != -1 {
             listWillDisappear(at: willAppearIndex)
             listWillAppear(at: willDisappearIndex)
@@ -532,10 +531,10 @@ extension JXPagingListContainerView: UICollectionViewDataSource, UICollectionVie
 }
 
 class JXPagingListContainerViewController: UIViewController {
-    var viewWillAppearClosure: (()->())?
-    var viewDidAppearClosure: (()->())?
-    var viewWillDisappearClosure: (()->())?
-    var viewDidDisappearClosure: (()->())?
+    var viewWillAppearClosure: (() -> Void)?
+    var viewDidAppearClosure: (() -> Void)?
+    var viewWillDisappearClosure: (() -> Void)?
+    var viewDidDisappearClosure: (() -> Void)?
     override var shouldAutomaticallyForwardAppearanceMethods: Bool { return false }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -562,12 +561,12 @@ class JXPagingListContainerScrollView: UIScrollView, UIGestureRecognizerDelegate
             let panGesture = gestureRecognizer as! UIPanGestureRecognizer
             let velocityX = panGesture.velocity(in: panGesture.view!).x
             if velocityX > 0 {
-                //当前在第一个页面，且往左滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
+                // 当前在第一个页面，且往左滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
                 if contentOffset.x == 0 {
                     return false
                 }
-            }else if velocityX < 0 {
-                //当前在最后一个页面，且往右滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
+            } else if velocityX < 0 {
+                // 当前在最后一个页面，且往右滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
                 if contentOffset.x + bounds.size.width == contentSize.width {
                     return false
                 }
@@ -579,16 +578,16 @@ class JXPagingListContainerScrollView: UIScrollView, UIGestureRecognizerDelegate
 class JXPagingListContainerCollectionView: UICollectionView, UIGestureRecognizerDelegate {
     var isCategoryNestPagingEnabled = false
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if isCategoryNestPagingEnabled, let panGestureClass = NSClassFromString("UIScrollViewPanGestureRecognizer"), gestureRecognizer.isMember(of: panGestureClass)  {
+        if isCategoryNestPagingEnabled, let panGestureClass = NSClassFromString("UIScrollViewPanGestureRecognizer"), gestureRecognizer.isMember(of: panGestureClass) {
             let panGesture = gestureRecognizer as! UIPanGestureRecognizer
             let velocityX = panGesture.velocity(in: panGesture.view!).x
             if velocityX > 0 {
-                //当前在第一个页面，且往左滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
+                // 当前在第一个页面，且往左滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
                 if contentOffset.x == 0 {
                     return false
                 }
-            }else if velocityX < 0 {
-                //当前在最后一个页面，且往右滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
+            } else if velocityX < 0 {
+                // 当前在最后一个页面，且往右滑动，就放弃该手势响应，让外层接收，达到多个PagingView左右切换效果
                 if contentOffset.x + bounds.size.width == contentSize.width {
                     return false
                 }

--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingListRefreshView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingListRefreshView.swift
@@ -20,26 +20,26 @@ open class JXPagingListRefreshView: JXPagingView {
     override open func preferredProcessMainTableViewDidScroll(_ scrollView: UIScrollView) {
         if pinSectionHeaderVerticalOffset != 0 {
             if !(currentScrollingListView != nil && currentScrollingListView!.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView!)) {
-                //没有处于滚动某一个listView的状态
+                // 没有处于滚动某一个listView的状态
                 if scrollView.contentOffset.y <= 0 {
                     mainTableView.bounces = false
                     mainTableView.contentOffset = CGPoint.zero
                     return
-                }else {
+                } else {
                     mainTableView.bounces = true
                 }
             }
         }
         guard let currentScrollingListView = currentScrollingListView else { return }
-        if (currentScrollingListView.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView)) {
-            //mainTableView的header已经滚动不见，开始滚动某一个listView，那么固定mainTableView的contentOffset，让其不动
+        if currentScrollingListView.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView) {
+            // mainTableView的header已经滚动不见，开始滚动某一个listView，那么固定mainTableView的contentOffset，让其不动
             setMainTableViewToMaxContentOffsetY()
         }
 
-        if (mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY()) {
-            //mainTableView已经显示了header，listView的contentOffset需要重置
+        if mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY() {
+            // mainTableView已经显示了header，listView的contentOffset需要重置
             for list in validListDict.values {
-                //正在下拉刷新时，不需要重置
+                // 正在下拉刷新时，不需要重置
                 if list.listScrollView().contentOffset.y > minContentOffsetYInListScrollView(list.listScrollView()) {
                     setListScrollViewToMinContentOffsetY(list.listScrollView())
                 }
@@ -47,43 +47,43 @@ open class JXPagingListRefreshView: JXPagingView {
         }
 
         if scrollView.contentOffset.y > mainTableViewMaxContentOffsetY() && currentScrollingListView.contentOffset.y == minContentOffsetYInListScrollView(currentScrollingListView) {
-            //当往上滚动mainTableView的headerView时，滚动到底时，修复listView往上小幅度滚动
+            // 当往上滚动mainTableView的headerView时，滚动到底时，修复listView往上小幅度滚动
             setMainTableViewToMaxContentOffsetY()
         }
     }
-    
+
     override open func preferredProcessListViewDidScroll(scrollView: UIScrollView) {
         guard let currentScrollingListView = currentScrollingListView else { return }
         var shouldProcess = true
         if currentScrollingListView.contentOffset.y > lastScrollingListViewContentOffsetY {
-            //往上滚动
-        }else {
-            //往下滚动
+            // 往上滚动
+        } else {
+            // 往下滚动
             if mainTableView.contentOffset.y == 0 {
                 shouldProcess = false
-            }else {
-                if (mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY()) {
-                    //mainTableView的header还没有消失，让listScrollView一直为0
+            } else {
+                if mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY() {
+                    // mainTableView的header还没有消失，让listScrollView一直为0
                     setListScrollViewToMinContentOffsetY(currentScrollingListView)
-                    currentScrollingListView.showsVerticalScrollIndicator = false;
+                    currentScrollingListView.showsVerticalScrollIndicator = false
                 }
             }
         }
         if shouldProcess {
-            if (mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY()) {
-                //处于下拉刷新的状态，scrollView.contentOffset.y为负数，就重置为0
+            if mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY() {
+                // 处于下拉刷新的状态，scrollView.contentOffset.y为负数，就重置为0
                 if currentScrollingListView.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView) {
-                    //mainTableView的header还没有消失，让listScrollView一直为0
+                    // mainTableView的header还没有消失，让listScrollView一直为0
                     setListScrollViewToMinContentOffsetY(currentScrollingListView)
-                    currentScrollingListView.showsVerticalScrollIndicator = false;
+                    currentScrollingListView.showsVerticalScrollIndicator = false
                 }
             } else {
-                //mainTableView的header刚好消失，固定mainTableView的位置，显示listScrollView的滚动条
+                // mainTableView的header刚好消失，固定mainTableView的位置，显示listScrollView的滚动条
                 setMainTableViewToMaxContentOffsetY()
-                currentScrollingListView.showsVerticalScrollIndicator = true;
+                currentScrollingListView.showsVerticalScrollIndicator = true
             }
         }
-        lastScrollingListViewContentOffsetY = currentScrollingListView.contentOffset.y;
+        lastScrollingListViewContentOffsetY = currentScrollingListView.contentOffset.y
     }
 
 }

--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingMainTableView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingMainTableView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc public protocol JXPagingMainTableViewGestureDelegate {
-    //如果headerView（或其他地方）有水平滚动的scrollView，当其正在左右滑动的时候，就不能让列表上下滑动，所以有此代理方法进行对应处理
+    // 如果headerView（或其他地方）有水平滚动的scrollView，当其正在左右滑动的时候，就不能让列表上下滑动，所以有此代理方法进行对应处理
     func mainTableViewGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool
 }
 
@@ -18,8 +18,8 @@ open class JXPagingMainTableView: UITableView, UIGestureRecognizerDelegate {
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureDelegate != nil {
-            return gestureDelegate!.mainTableViewGestureRecognizer(gestureRecognizer, shouldRecognizeSimultaneouslyWith:otherGestureRecognizer)
-        }else {
+            return gestureDelegate!.mainTableViewGestureRecognizer(gestureRecognizer, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer)
+        } else {
             return gestureRecognizer.isKind(of: UIPanGestureRecognizer.self) && otherGestureRecognizer.isKind(of: UIPanGestureRecognizer.self)
         }
     }

--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingSmoothView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingSmoothView.swift
@@ -40,15 +40,14 @@ public protocol JXPagingSmoothViewDelegate {
     @objc optional func pagingSmoothViewDidScroll(_ scrollView: UIScrollView)
 }
 
-
 open class JXPagingSmoothView: UIView {
-    public private(set) var listDict = [Int : JXPagingSmoothViewListViewDelegate]()
+    public private(set) var listDict = [Int: JXPagingSmoothViewListViewDelegate]()
     public let listCollectionView: JXPagingSmoothCollectionView
     public var defaultSelectedIndex: Int = 0
     public weak var delegate: JXPagingSmoothViewDelegate?
 
     weak var dataSource: JXPagingSmoothViewDataSource?
-    var listHeaderDict = [Int : UIView]()
+    var listHeaderDict = [Int: UIView]()
     var isSyncListContentOffsetEnabled: Bool = false
     let pagingHeaderContainerView: UIView
     var currentPagingHeaderContainerViewY: CGFloat = 0
@@ -134,7 +133,7 @@ open class JXPagingSmoothView: UIView {
             addSubview(singleScrollView!)
             singleScrollView?.addSubview(pagingHeader)
             singleScrollView?.contentSize = CGSize(width: bounds.size.width, height: heightForPagingHeader)
-        }else if singleScrollView != nil {
+        } else if singleScrollView != nil {
             singleScrollView?.removeFromSuperview()
             singleScrollView = nil
         }
@@ -175,7 +174,7 @@ open class JXPagingSmoothView: UIView {
                 pagingHeaderContainerView.frame.origin.y = 0
                 header?.addSubview(pagingHeaderContainerView)
             }
-        }else {
+        } else {
             if pagingHeaderContainerView.superview != self {
                 pagingHeaderContainerView.frame.origin.y = -heightForPagingHeader
                 addSubview(pagingHeaderContainerView)
@@ -192,30 +191,30 @@ open class JXPagingSmoothView: UIView {
         }
     }
 
-    //MARK: - KVO
+    // MARK: - KVO
 
-    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == "contentOffset" {
             if let scrollView = object as? UIScrollView {
                 listDidScroll(scrollView: scrollView)
             }
-        }else if keyPath == "contentSize" {
+        } else if keyPath == "contentSize" {
             if let scrollView = object as? UIScrollView {
                 let minContentSizeHeight = bounds.size.height - heightForPinHeader
                 if minContentSizeHeight > scrollView.contentSize.height {
                     scrollView.contentSize = CGSize(width: scrollView.contentSize.width, height: minContentSizeHeight)
-                    //新的scrollView第一次加载的时候重置contentOffset
+                    // 新的scrollView第一次加载的时候重置contentOffset
                     if currentListScrollView != nil, scrollView != currentListScrollView! {
                         scrollView.contentOffset = CGPoint(x: 0, y: currentListInitializeContentOffsetY)
                     }
                 }
             }
-        }else {
+        } else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
     }
 
-    //MARK: - Private
+    // MARK: - Private
     func listHeader(for listScrollView: UIScrollView) -> UIView? {
         for (index, list) in listDict {
             if list.listScrollView() == listScrollView {
@@ -329,8 +328,8 @@ extension JXPagingSmoothView: UICollectionViewDataSource, UICollectionViewDelega
         let listScrollView = listDict[index]?.listScrollView()
         if (indexPercent - CGFloat(index) == 0) && index != currentIndex && !(scrollView.isDragging || scrollView.isDecelerating) && listScrollView?.contentOffset.y ?? 0 <= -heightForPinHeader {
             horizontalScrollDidEnd(at: index)
-        }else {
-            //左右滚动的时候，就把listHeaderContainerView添加到self，达到悬浮在顶部的效果
+        } else {
+            // 左右滚动的时候，就把listHeaderContainerView添加到self，达到悬浮在顶部的效果
             if pagingHeaderContainerView.superview != self {
                 pagingHeaderContainerView.frame.origin.y = currentPagingHeaderContainerViewY
                 addSubview(pagingHeaderContainerView)

--- a/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/JXPagingView/JXPagingView.swift
@@ -37,7 +37,6 @@ import UIKit
     @objc optional func pagingView(_ pagingView: JXPagingView, mainTableViewDidEndDecelerating scrollView: UIScrollView)
     @objc optional func pagingView(_ pagingView: JXPagingView, mainTableViewDidEndScrollingAnimation scrollView: UIScrollView)
 
-
     /// 返回自定义UIScrollView或UICollectionView的Class
     /// 某些特殊情况需要自己处理列表容器内UIScrollView内部逻辑。比如项目用了FDFullscreenPopGesture，需要处理手势相关代理。
     ///
@@ -56,7 +55,7 @@ open class JXPagingView: UIView {
     public private(set) lazy var mainTableView: JXPagingMainTableView = JXPagingMainTableView(frame: CGRect.zero, style: .plain)
     public private(set) lazy var listContainerView: JXPagingListContainerView = JXPagingListContainerView(dataSource: self, type: listContainerType)
     /// 当前已经加载过可用的列表字典，key就是index值，value是对应的列表。
-    public private(set) var validListDict = [Int:JXPagingViewListViewDelegate]()
+    public private(set) var validListDict = [Int: JXPagingViewListViewDelegate]()
     /// 顶部固定sectionHeader的垂直偏移量。数值越大越往下沉。
     public var pinSectionHeaderVerticalOffset: Int = 0
     public var isListHorizontalScrollEnabled = true {
@@ -139,7 +138,7 @@ open class JXPagingView: UIView {
                 self.mainTableView.setNeedsLayout()
                 self.mainTableView.layoutIfNeeded()
             }, completion: nil)
-        }else {
+        } else {
             var bounds = tableHeaderContainerView.bounds
             bounds.size.height = CGFloat(delegate.tableHeaderViewHeight(in: self))
             tableHeaderContainerView.frame = bounds
@@ -148,15 +147,15 @@ open class JXPagingView: UIView {
     }
 
     open func preferredProcessListViewDidScroll(scrollView: UIScrollView) {
-        if (mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY()) {
-            //mainTableView的header还没有消失，让listScrollView一直为0
+        if mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY() {
+            // mainTableView的header还没有消失，让listScrollView一直为0
             currentList?.listScrollViewWillResetContentOffset?()
             setListScrollViewToMinContentOffsetY(scrollView)
             if automaticallyDisplayListVerticalScrollIndicator {
                 scrollView.showsVerticalScrollIndicator = false
             }
         } else {
-            //mainTableView的header刚好消失，固定mainTableView的位置，显示listScrollView的滚动条
+            // mainTableView的header刚好消失，固定mainTableView的位置，显示listScrollView的滚动条
             setMainTableViewToMaxContentOffsetY()
             if automaticallyDisplayListVerticalScrollIndicator {
                 scrollView.showsVerticalScrollIndicator = true
@@ -166,13 +165,13 @@ open class JXPagingView: UIView {
 
     open func preferredProcessMainTableViewDidScroll(_ scrollView: UIScrollView) {
         guard let currentScrollingListView = currentScrollingListView else { return }
-        if (currentScrollingListView.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView)) {
-            //mainTableView的header已经滚动不见，开始滚动某一个listView，那么固定mainTableView的contentOffset，让其不动
+        if currentScrollingListView.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView) {
+            // mainTableView的header已经滚动不见，开始滚动某一个listView，那么固定mainTableView的contentOffset，让其不动
             setMainTableViewToMaxContentOffsetY()
         }
 
-        if (mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY()) {
-            //mainTableView已经显示了header，listView的contentOffset需要重置
+        if mainTableView.contentOffset.y < mainTableViewMaxContentOffsetY() {
+            // mainTableView已经显示了header，listView的contentOffset需要重置
             for list in validListDict.values {
                 list.listScrollViewWillResetContentOffset?()
                 setListScrollViewToMinContentOffsetY(list.listScrollView())
@@ -180,12 +179,12 @@ open class JXPagingView: UIView {
         }
 
         if scrollView.contentOffset.y > mainTableViewMaxContentOffsetY() && currentScrollingListView.contentOffset.y == minContentOffsetYInListScrollView(currentScrollingListView) {
-            //当往上滚动mainTableView的headerView时，滚动到底时，修复listView往上小幅度滚动
+            // 当往上滚动mainTableView的headerView时，滚动到底时，修复listView往上小幅度滚动
             setMainTableViewToMaxContentOffsetY()
         }
     }
 
-    //MARK: - Private
+    // MARK: - Private
 
     func refreshTableHeaderView() {
         guard let delegate = delegate else { return }
@@ -204,15 +203,15 @@ open class JXPagingView: UIView {
 
     func adjustMainScrollViewToTargetContentInsetIfNeeded(inset: UIEdgeInsets) {
         if mainTableView.contentInset != inset {
-            //防止循环调用
+            // 防止循环调用
             mainTableView.delegate = nil
             mainTableView.contentInset = inset
             mainTableView.delegate = self
         }
     }
 
-    //仅用于处理设置了pinSectionHeaderVerticalOffset，又添加了MJRefresh的下拉刷新。这种情况会导致JXPagingView和MJRefresh来回设置contentInset值。针对这种及其特殊的情况，就内部特殊处理了。通过下面的判断条件，来判定当前是否处于下拉刷新中。请勿让pinSectionHeaderVerticalOffset和下拉刷新设置的contentInset.top值相同。
-    //具体原因参考：https://github.com/pujiaxin33/JXPagingView/issues/203
+    // 仅用于处理设置了pinSectionHeaderVerticalOffset，又添加了MJRefresh的下拉刷新。这种情况会导致JXPagingView和MJRefresh来回设置contentInset值。针对这种及其特殊的情况，就内部特殊处理了。通过下面的判断条件，来判定当前是否处于下拉刷新中。请勿让pinSectionHeaderVerticalOffset和下拉刷新设置的contentInset.top值相同。
+    // 具体原因参考：https://github.com/pujiaxin33/JXPagingView/issues/203
     func isSetMainScrollViewContentInsetToZeroEnabled(scrollView: UIScrollView) -> Bool {
         return !(scrollView.contentInset.top != 0 && scrollView.contentInset.top != CGFloat(pinSectionHeaderVerticalOffset))
     }
@@ -249,7 +248,7 @@ open class JXPagingView: UIView {
     }
 }
 
-//MARK: - UITableViewDataSource, UITableViewDelegate
+// MARK: - UITableViewDataSource, UITableViewDelegate
 extension JXPagingView: UITableViewDataSource, UITableViewDelegate {
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1
@@ -281,7 +280,7 @@ extension JXPagingView: UITableViewDataSource, UITableViewDelegate {
         return delegate.viewForPinSectionHeader(in: self)
     }
 
-    //加上footer之后，下滑滚动就变得丝般顺滑了
+    // 加上footer之后，下滑滚动就变得丝般顺滑了
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return 1
     }
@@ -295,11 +294,11 @@ extension JXPagingView: UITableViewDataSource, UITableViewDelegate {
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if pinSectionHeaderVerticalOffset != 0 {
             if !(currentScrollingListView != nil && currentScrollingListView!.contentOffset.y > minContentOffsetYInListScrollView(currentScrollingListView!)) {
-                //没有处于滚动某一个listView的状态
+                // 没有处于滚动某一个listView的状态
                 if scrollView.contentOffset.y >= CGFloat(pinSectionHeaderVerticalOffset) {
-                    //固定的位置就是contentInset.top
+                    // 固定的位置就是contentInset.top
                    adjustMainScrollViewToTargetContentInsetIfNeeded(inset: UIEdgeInsets(top: CGFloat(pinSectionHeaderVerticalOffset), left: 0, bottom: 0, right: 0))
-                }else {
+                } else {
                     if isSetMainScrollViewContentInsetToZeroEnabled(scrollView: scrollView) {
                         adjustMainScrollViewToTargetContentInsetIfNeeded(inset: UIEdgeInsets.zero)
                     }
@@ -312,7 +311,7 @@ extension JXPagingView: UITableViewDataSource, UITableViewDelegate {
     }
 
     open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        //用户正在上下滚动的时候，就不允许左右滚动
+        // 用户正在上下滚动的时候，就不允许左右滚动
         listContainerView.scrollView.isScrollEnabled = false
         delegate?.pagingView?(self, mainTableViewWillBeginDragging: scrollView)
     }
@@ -386,11 +385,9 @@ extension JXPagingView: JXPagingListContainerViewDelegate {
         for listItem in validListDict.values {
             if listItem === validListDict[index] {
                 listItem.listScrollView().scrollsToTop = true
-            }else {
+            } else {
                 listItem.listScrollView().scrollsToTop = false
             }
         }
     }
 }
-
-

--- a/Example/JXSegmentedViewExample/Special/Personal/PagingListBaseCell.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/PagingListBaseCell.swift
@@ -9,22 +9,22 @@
 import UIKit
 
 class PagingListBaseCell: UITableViewCell {
-    
+
     private(set) lazy var titleLabel = UILabel()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         commonInit()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         commonInit()
     }
-    
+
     func commonInit() {
         contentView.addSubview(titleLabel)
-        
+
         let leading = NSLayoutConstraint(item: titleLabel, attribute: .leading, relatedBy: .equal, toItem: contentView, attribute: .leading, multiplier: 1, constant: 10)
         let top = NSLayoutConstraint(item: titleLabel, attribute: .top, relatedBy: .equal, toItem: contentView, attribute: .top, multiplier: 1, constant: 10)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Example/JXSegmentedViewExample/Special/Personal/PagingListBaseView.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/PagingListBaseView.swift
@@ -11,7 +11,7 @@ import UIKit
 @objc public class PagingListBaseView: UIView {
     @objc public var tableView: UITableView!
     @objc public var dataSource: [String]?
-    var listViewDidScrollCallback: ((UIScrollView) -> ())?
+    var listViewDidScrollCallback: ((UIScrollView) -> Void)?
     private var isHeaderRefreshed: Bool = false
     deinit {
         listViewDidScrollCallback = nil
@@ -35,7 +35,6 @@ import UIKit
             self.tableView.reloadData()
         }
     }
-
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -76,8 +75,8 @@ extension PagingListBaseView: JXPagingViewListViewDelegate {
     public func listView() -> UIView {
         return self
     }
-    
-    public func listViewDidScrollCallback(callback: @escaping (UIScrollView) -> ()) {
+
+    public func listViewDidScrollCallback(callback: @escaping (UIScrollView) -> Void) {
         self.listViewDidScrollCallback = callback
     }
 

--- a/Example/JXSegmentedViewExample/Special/Personal/PagingViewController.swift
+++ b/Example/JXSegmentedViewExample/Special/Personal/PagingViewController.swift
@@ -31,7 +31,7 @@ class PagingViewController: UIViewController {
         userHeaderView = PagingViewTableHeaderView(frame: userHeaderContainerView.bounds)
         userHeaderContainerView.addSubview(userHeaderView)
 
-        //segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
+        // segmentedViewDataSource一定要通过属性强持有！！！！！！！！！
         segmentedViewDataSource = JXSegmentedTitleDataSource()
         segmentedViewDataSource.titles = titles
         segmentedViewDataSource.titleSelectedColor = UIColor(red: 105/255, green: 144/255, blue: 239/255, alpha: 1)
@@ -58,7 +58,7 @@ class PagingViewController: UIViewController {
         pagingView = JXPagingView(delegate: self)
 
         self.view.addSubview(pagingView)
-        
+
         segmentedView.listContainer = pagingView.listContainerView
     }
 
@@ -95,9 +95,9 @@ extension PagingViewController: JXPagingViewDelegate {
         let list = PagingListBaseView()
         if index == 0 {
             list.dataSource = ["橡胶火箭", "橡胶火箭炮", "橡胶机关枪", "橡胶子弹", "橡胶攻城炮", "橡胶象枪", "橡胶象枪乱打", "橡胶灰熊铳", "橡胶雷神象枪", "橡胶猿王枪", "橡胶犀·榴弹炮", "橡胶大蛇炮", "橡胶火箭", "橡胶火箭炮", "橡胶机关枪", "橡胶子弹", "橡胶攻城炮", "橡胶象枪", "橡胶象枪乱打", "橡胶灰熊铳", "橡胶雷神象枪", "橡胶猿王枪", "橡胶犀·榴弹炮", "橡胶大蛇炮"]
-        }else if index == 1 {
+        } else if index == 1 {
             list.dataSource = ["吃烤肉", "吃鸡腿肉", "吃牛肉", "各种肉"]
-        }else {
+        } else {
             list.dataSource = ["【剑士】罗罗诺亚·索隆", "【航海士】娜美", "【狙击手】乌索普", "【厨师】香吉士", "【船医】托尼托尼·乔巴", "【船匠】 弗兰奇", "【音乐家】布鲁克", "【考古学家】妮可·罗宾"]
         }
         list.beginFirstRefresh()
@@ -108,4 +108,3 @@ extension PagingViewController: JXPagingViewDelegate {
         userHeaderView?.scrollViewDidScroll(contentOffsetY: scrollView.contentOffset.y)
     }
 }
-

--- a/Example/JXSegmentedViewExample/ViewController.swift
+++ b/Example/JXSegmentedViewExample/ViewController.swift
@@ -46,4 +46,3 @@ class ViewController: UITableViewController {
         }
     }
 }
-

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "JXSegmentedView",
-            targets: ["JXSegmentedView"]),
+            targets: ["JXSegmentedView"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -26,6 +26,6 @@ let package = Package(
             name: "JXSegmentedView",
             dependencies: [],
             path: "Sources"
-        ),
+        )
     ]
 )

--- a/Sources/AttributeTitle/JXSegmentedTitleAttributeCell.swift
+++ b/Sources/AttributeTitle/JXSegmentedTitleAttributeCell.swift
@@ -34,7 +34,7 @@ open class JXSegmentedTitleAttributeCell: JXSegmentedBaseCell {
         titleLabel.numberOfLines = myItemModel.titleNumberOfLines
         if myItemModel.isSelected && myItemModel.selectedAttributedTitle != nil {
             titleLabel.attributedText = myItemModel.selectedAttributedTitle
-        }else {
+        } else {
             titleLabel.attributedText = myItemModel.attributedTitle
         }
     }

--- a/Sources/AttributeTitle/JXSegmentedTitleAttributeDataSource.swift
+++ b/Sources/AttributeTitle/JXSegmentedTitleAttributeDataSource.swift
@@ -14,7 +14,7 @@ open class JXSegmentedTitleAttributeDataSource: JXSegmentedBaseDataSource {
     /// 选中时的富文本，可选。如果要使用确保count与attributedTitles一致。
     open var selectedAttributedTitles: [NSAttributedString]?
     /// 如果将JXSegmentedView嵌套进UITableView的cell，每次重用的时候，JXSegmentedView进行reloadData时，会重新计算所有的title宽度。所以该应用场景，需要UITableView的cellModel缓存titles的文字宽度，再通过该闭包方法返回给JXSegmentedView。
-    open var widthForTitleClosure: ((NSAttributedString)->(CGFloat))?
+    open var widthForTitleClosure: ((NSAttributedString) -> (CGFloat))?
     /// title的numberOfLines
     open var titleNumberOfLines: Int = 2
 
@@ -46,7 +46,7 @@ open class JXSegmentedTitleAttributeDataSource: JXSegmentedBaseDataSource {
         }
         if widthForTitleClosure != nil {
             return widthForTitleClosure!(text)
-        }else {
+        } else {
             let textWidth = text.boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: NSStringDrawingOptions.init(rawValue: NSStringDrawingOptions.usesLineFragmentOrigin.rawValue | NSStringDrawingOptions.usesFontLeading.rawValue), context: nil).size.width
             return CGFloat(ceilf(Float(textWidth)))
         }
@@ -58,13 +58,13 @@ open class JXSegmentedTitleAttributeDataSource: JXSegmentedBaseDataSource {
         if itemWidth == JXSegmentedViewAutomaticDimension {
             let myItemModel = dataSource[index] as! JXSegmentedTitleAttributeItemModel
             width = myItemModel.textWidth + itemWidthIncrement
-        }else {
+        } else {
             width = itemWidth + itemWidthIncrement
         }
         return width
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleAttributeCell.self, forCellWithReuseIdentifier: "cell")
     }

--- a/Sources/Common/JXSegmentedAnimator.swift
+++ b/Sources/Common/JXSegmentedAnimator.swift
@@ -11,8 +11,8 @@ import UIKit
 
 open class JXSegmentedAnimator {
     open var duration: TimeInterval = 0.25
-    open var progressClosure: ((CGFloat)->())?
-    open var completedClosure: (()->())?
+    open var progressClosure: ((CGFloat) -> Void)?
+    open var completedClosure: (() -> Void)?
     private var displayLink: CADisplayLink!
     private var firstTimestamp: CFTimeInterval?
 
@@ -39,7 +39,7 @@ open class JXSegmentedAnimator {
             progressClosure?(1)
             displayLink.invalidate()
             completedClosure?()
-        }else {
+        } else {
             progressClosure?(CGFloat(percent))
         }
     }

--- a/Sources/Common/JXSegmentedListContainerView.swift
+++ b/Sources/Common/JXSegmentedListContainerView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// 列表容器视图的类型
-///- ScrollView: UIScrollView。优势：没有其他副作用。劣势：视图内存占用相对大一点。因为所有的列表视图都在UIScrollView的视图层级里面。
+/// - ScrollView: UIScrollView。优势：没有其他副作用。劣势：视图内存占用相对大一点。因为所有的列表视图都在UIScrollView的视图层级里面。
 /// - CollectionView: 使用UICollectionView。优势：因为列表被添加到cell上，视图的内存占用更少，适合内存要求特别高的场景。劣势：因为cell重用机制的问题，导致列表下拉刷新视图(比如MJRefresh)，会因为被removeFromSuperview而被隐藏。所以，列表有下拉刷新需求的，请使用scrollView type。
 public enum JXSegmentedListContainerType {
     case scrollView
@@ -45,7 +45,6 @@ public protocol JXSegmentedListContainerViewDataSource {
     /// - Returns: 遵从JXSegmentedListContainerViewListDelegate协议的实例
     func listContainerView(_ listContainerView: JXSegmentedListContainerView, initListAt index: Int) -> JXSegmentedListContainerViewListDelegate
 
-
     /// 控制能否初始化对应index的列表。有些业务需求，需要在某些情况才允许初始化某些列表，通过通过该代理实现控制。
     @objc optional func listContainerView(_ listContainerView: JXSegmentedListContainerView, canInitListAt index: Int) -> Bool
 
@@ -62,7 +61,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
     open private(set) weak var dataSource: JXSegmentedListContainerViewDataSource?
     open private(set) var scrollView: UIScrollView!
     /// 已经加载过的列表字典。key是index，value是对应的列表
-    open private(set) var validListDict = [Int:JXSegmentedListContainerViewListDelegate]()
+    open private(set) var validListDict = [Int: JXSegmentedListContainerViewListDelegate]()
     /// 滚动切换的时候，滚动距离超过一页的多少百分比，就触发列表的初始化。默认0.01（即列表显示了一点就触发加载）。范围0~1，开区间不包括0和1
     open var initListPercent: CGFloat = 0.01 {
         didSet {
@@ -86,7 +85,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         layout.minimumInteritemSpacing = 0
         if let collectionViewClass = dataSource?.scrollViewClass?(in: self) as? UICollectionView.Type {
             return collectionViewClass.init(frame: CGRect.zero, collectionViewLayout: layout)
-        }else {
+        } else {
             return UICollectionView.init(frame: CGRect.zero, collectionViewLayout: layout)
         }
     }()
@@ -124,7 +123,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         if type == .scrollView {
             if let scrollViewClass = dataSource?.scrollViewClass?(in: self) as? UIScrollView.Type {
                 scrollView = scrollViewClass.init()
-            }else {
+            } else {
                 scrollView = UIScrollView.init()
             }
             scrollView.delegate = self
@@ -140,7 +139,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
                 segmentedView(horizontalFlipForView: scrollView)
             }
             containerVC.view.addSubview(scrollView)
-        }else if type == .collectionView {
+        } else if type == .collectionView {
             collectionView.isPagingEnabled = true
             collectionView.showsHorizontalScrollIndicator = false
             collectionView.showsVerticalScrollIndicator = false
@@ -160,7 +159,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
                 segmentedView(horizontalFlipForView: collectionView)
             }
             containerVC.view.addSubview(collectionView)
-            //让外部统一访问scrollView
+            // 让外部统一访问scrollView
             scrollView = collectionView
         }
     }
@@ -169,7 +168,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         super.willMove(toSuperview: newSuperview)
         var next: UIResponder? = newSuperview
         while next != nil {
-            if let vc = next as? UIViewController{
+            if let vc = next as? UIViewController {
                 vc.addChild(containerVC)
                 break
             }
@@ -192,22 +191,22 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
                     list.listView().frame = CGRect(x: CGFloat(index)*scrollView.bounds.size.width, y: 0, width: scrollView.bounds.size.width, height: scrollView.bounds.size.height)
                 }
                 scrollView.contentOffset = CGPoint(x: CGFloat(currentIndex)*scrollView.bounds.size.width, y: 0)
-            }else {
+            } else {
                 scrollView.frame = bounds
                 scrollView.contentSize = CGSize(width: scrollView.bounds.size.width*CGFloat(count), height: scrollView.bounds.size.height)
             }
-        }else {
+        } else {
             if collectionView.frame == CGRect.zero || collectionView.bounds.size != bounds.size {
                 collectionView.frame = bounds
                 collectionView.collectionViewLayout.invalidateLayout()
                 collectionView.setContentOffset(CGPoint(x: CGFloat(currentIndex)*collectionView.bounds.size.width, y: 0), animated: false)
-            }else {
+            } else {
                 collectionView.frame = bounds
             }
         }
     }
 
-    //MARK: - JXSegmentedViewListContainer
+    // MARK: - JXSegmentedViewListContainer
 
     public func contentScrollView() -> UIScrollView {
            return scrollView
@@ -245,14 +244,14 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         validListDict.removeAll()
         if type == .scrollView {
             scrollView.contentSize = CGSize(width: scrollView.bounds.size.width*CGFloat(dataSource.numberOfLists(in: self)), height: scrollView.bounds.size.height)
-        }else {
+        } else {
             collectionView.reloadData()
         }
         listWillAppear(at: currentIndex)
         listDidAppear(at: currentIndex)
     }
 
-    //MARK: - Private
+    // MARK: - Private
     func initListIfNeeded(at index: Int) {
         guard let dataSource = dataSource else { return }
         if dataSource.listContainerView?(self, canInitListAt: index) == false {
@@ -260,7 +259,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         }
         var existedList = validListDict[index]
         if existedList != nil {
-            //列表已经创建好了
+            // 列表已经创建好了
             return
         }
         existedList = dataSource.listContainerView(self, initListAt: index)
@@ -274,11 +273,11 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
         if type == .scrollView {
             list.listView().frame = CGRect(x: CGFloat(index)*scrollView.bounds.size.width, y: 0, width: scrollView.bounds.size.width, height: scrollView.bounds.size.height)
             scrollView.addSubview(list.listView())
-            
+
             if segmentedViewShouldRTLLayout() {
                 segmentedView(horizontalFlipForView: list.listView())
             }
-        }else {
+        } else {
             let cell = collectionView.cellForItem(at: IndexPath(item: index, section: 0))
             cell?.contentView.subviews.forEach { $0.removeFromSuperview() }
             list.listView().frame = cell?.contentView.bounds ?? CGRect.zero
@@ -297,8 +296,8 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
             if let vc = existedList as? UIViewController {
                 vc.beginAppearanceTransition(true, animated: false)
             }
-        }else {
-            //当前列表未被创建（页面初始化或通过点击触发的listWillAppear）
+        } else {
+            // 当前列表未被创建（页面初始化或通过点击触发的listWillAppear）
             guard dataSource.listContainerView?(self, canInitListAt: index) != false else {
                 return
             }
@@ -314,7 +313,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
                 if list.listView().superview == nil {
                     list.listView().frame = CGRect(x: CGFloat(index)*scrollView.bounds.size.width, y: 0, width: scrollView.bounds.size.width, height: scrollView.bounds.size.height)
                     scrollView.addSubview(list.listView())
-                    
+
                     if segmentedViewShouldRTLLayout() {
                         segmentedView(horizontalFlipForView: list.listView())
                     }
@@ -323,7 +322,7 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
                 if let vc = list as? UIViewController {
                     vc.beginAppearanceTransition(true, animated: false)
                 }
-            }else {
+            } else {
                 let cell = collectionView.cellForItem(at: IndexPath(item: index, section: 0))
                 cell?.contentView.subviews.forEach { $0.removeFromSuperview() }
                 list.listView().frame = cell?.contentView.bounds ?? CGRect.zero
@@ -385,15 +384,15 @@ open class JXSegmentedListContainerView: UIView, JXSegmentedViewListContainer, J
             let disappearIndex = willDisappearIndex
             let appearIndex = willAppearIndex
             if willAppearIndex > willDisappearIndex {
-                //将要出现的列表在右边
+                // 将要出现的列表在右边
                 if currentIndexPercent >= CGFloat(willAppearIndex) {
                     willDisappearIndex = -1
                     willAppearIndex = -1
                     listDidDisappear(at: disappearIndex)
                     listDidAppear(at: appearIndex)
                 }
-            }else {
-                //将要出现的列表在左边
+            } else {
+                // 将要出现的列表在左边
                 if currentIndexPercent <= CGFloat(willAppearIndex) {
                     willDisappearIndex = -1
                     willAppearIndex = -1
@@ -435,19 +434,19 @@ extension JXSegmentedListContainerView: UICollectionViewDataSource, UICollection
         let maxCount = Int(round(scrollView.contentSize.width/scrollView.bounds.size.width))
         var leftIndex = Int(floor(Double(percent)))
         leftIndex = max(0, min(maxCount - 1, leftIndex))
-        let rightIndex = leftIndex + 1;
+        let rightIndex = leftIndex + 1
         if percent < 0 || rightIndex >= maxCount {
             listDidAppearOrDisappear(scrollView: scrollView)
             return
         }
         let remainderRatio = percent - CGFloat(leftIndex)
         if rightIndex == currentIndex {
-            //当前选中的在右边，用户正在从右边往左边滑动
+            // 当前选中的在右边，用户正在从右边往左边滑动
             if validListDict[leftIndex] == nil && remainderRatio < (1 - initListPercent) {
                 initListIfNeeded(at: leftIndex)
-            }else if validListDict[leftIndex] != nil {
+            } else if validListDict[leftIndex] != nil {
                 if willAppearIndex == -1 {
-                    willAppearIndex = leftIndex;
+                    willAppearIndex = leftIndex
                     listWillAppear(at: willAppearIndex)
                 }
             }
@@ -456,11 +455,11 @@ extension JXSegmentedListContainerView: UICollectionViewDataSource, UICollection
                 willDisappearIndex = rightIndex
                 listWillDisappear(at: willDisappearIndex)
             }
-        }else {
-            //当前选中的在左边，用户正在从左边往右边滑动
+        } else {
+            // 当前选中的在左边，用户正在从左边往右边滑动
             if validListDict[rightIndex] == nil && remainderRatio > initListPercent {
                 initListIfNeeded(at: rightIndex)
-            }else if validListDict[rightIndex] != nil {
+            } else if validListDict[rightIndex] != nil {
                 if willAppearIndex == -1 {
                     willAppearIndex = rightIndex
                     listWillAppear(at: willAppearIndex)
@@ -475,7 +474,7 @@ extension JXSegmentedListContainerView: UICollectionViewDataSource, UICollection
     }
 
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        //滑动到一半又取消滑动处理
+        // 滑动到一半又取消滑动处理
         if willAppearIndex != -1 || willDisappearIndex != -1 {
             listWillDisappear(at: willAppearIndex)
             listWillAppear(at: willDisappearIndex)
@@ -488,10 +487,10 @@ extension JXSegmentedListContainerView: UICollectionViewDataSource, UICollection
 }
 
 class JXSegmentedListContainerViewController: UIViewController {
-    var viewWillAppearClosure: (()->())?
-    var viewDidAppearClosure: (()->())?
-    var viewWillDisappearClosure: (()->())?
-    var viewDidDisappearClosure: (()->())?
+    var viewWillAppearClosure: (()->Void)?
+    var viewDidAppearClosure: (()->Void)?
+    var viewWillDisappearClosure: (()->Void)?
+    var viewDidDisappearClosure: (()->Void)?
     override var shouldAutomaticallyForwardAppearanceMethods: Bool { return false }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/Sources/Common/JXSegmentedRTLLayout.swift
+++ b/Sources/Common/JXSegmentedRTLLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol JXSegmentedViewRTLCompatible: class {
+public protocol JXSegmentedViewRTLCompatible: AnyObject {
     func segmentedViewShouldRTLLayout() -> Bool
     func segmentedView(horizontalFlipForView view: UIView?)
 }

--- a/Sources/Common/JXSegmentedRTLLayout.swift
+++ b/Sources/Common/JXSegmentedRTLLayout.swift
@@ -14,37 +14,37 @@ public protocol JXSegmentedViewRTLCompatible: class {
 }
 
 public extension JXSegmentedViewRTLCompatible {
-    
+
     /// 根据当前系统布局方式返回是否需要RTL布局
     func segmentedViewShouldRTLLayout() -> Bool {
         return UIView.userInterfaceLayoutDirection(for: UIView.appearance().semanticContentAttribute) == .rightToLeft
     }
-    
+
     /// 在RTL布局下水平翻转当前视图
     /// - Parameter view: 需要翻转的视图
     func segmentedView(horizontalFlipForView view: UIView?) {
         view?.transform = CGAffineTransform(scaleX: -1, y: 1)
     }
-    
+
 }
 
 class JXSegmentedRTLCollectionCell: UICollectionViewCell, JXSegmentedViewRTLCompatible {
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         commonInit()
     }
-    
+
     func commonInit() {
         if segmentedViewShouldRTLLayout() {
             segmentedView(horizontalFlipForView: self)
             segmentedView(horizontalFlipForView: contentView)
         }
     }
-    
+
 }

--- a/Sources/Common/JXSegmentedViewTool.swift
+++ b/Sources/Common/JXSegmentedViewTool.swift
@@ -31,7 +31,7 @@ public extension UIColor {
 }
 
 public class JXSegmentedViewTool {
-    public static func interpolate<T: SignedNumeric & Comparable>(from: T, to:  T, percent:  T) ->  T {
+    public static func interpolate<T: SignedNumeric & Comparable>(from: T, to: T, percent: T) -> T {
         let percent = max(0, min(1, percent))
         return from + (to - from) * percent
     }

--- a/Sources/Core/JXSegmentedBaseCell.swift
+++ b/Sources/Core/JXSegmentedBaseCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public typealias JXSegmentedCellSelectedAnimationClosure = (CGFloat)->()
+public typealias JXSegmentedCellSelectedAnimationClosure = (CGFloat) -> Void
 
 open class JXSegmentedBaseCell: UICollectionViewCell, JXSegmentedViewRTLCompatible {
     open var itemModel: JXSegmentedBaseItemModel?
@@ -49,12 +49,12 @@ open class JXSegmentedBaseCell: UICollectionViewCell, JXSegmentedViewRTLCompatib
         var isSelectedAnimatable = false
         if itemModel.isSelectedAnimable {
             if selectedType == .scroll {
-                //滚动选中且没有开启左右过渡，允许动画
+                // 滚动选中且没有开启左右过渡，允许动画
                 if !itemModel.isItemTransitionEnabled {
                     isSelectedAnimatable = true
                 }
-            }else if selectedType == .click || selectedType == .code {
-                //点击和代码选中，允许动画
+            } else if selectedType == .click || selectedType == .code {
+                // 点击和代码选中，允许动画
                 isSelectedAnimatable = true
             }
         }
@@ -67,7 +67,7 @@ open class JXSegmentedBaseCell: UICollectionViewCell, JXSegmentedViewRTLCompatib
 
     open func startSelectedAnimationIfNeeded(itemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType) {
         if itemModel.isSelectedAnimable && canStartSelectedAnimation(itemModel: itemModel, selectedType: selectedType) {
-            //需要更新isTransitionAnimating，用于处理在过滤时，禁止响应点击，避免界面异常。
+            // 需要更新isTransitionAnimating，用于处理在过滤时，禁止响应点击，避免界面异常。
             itemModel.isTransitionAnimating = true
             animator?.progressClosure = {[weak self] (percent) in
                 guard self != nil else {
@@ -93,7 +93,7 @@ open class JXSegmentedBaseCell: UICollectionViewCell, JXSegmentedViewRTLCompatib
             if canStartSelectedAnimation(itemModel: itemModel, selectedType: selectedType) {
                 animator = JXSegmentedAnimator()
                 animator?.duration = itemModel.selectedAnimationDuration
-            }else {
+            } else {
                 animator?.stop()
                 animator = nil
             }

--- a/Sources/Core/JXSegmentedBaseDataSource.swift
+++ b/Sources/Core/JXSegmentedBaseDataSource.swift
@@ -64,7 +64,7 @@ open class JXSegmentedBaseDataSource: JXSegmentedViewDataSource {
     }
 
     /// 子类需要重载该方法，用于返回自己定义的JXSegmentedBaseItemModel子类实例
-    open func preferredItemModelInstance() -> JXSegmentedBaseItemModel  {
+    open func preferredItemModelInstance() -> JXSegmentedBaseItemModel {
         return JXSegmentedBaseItemModel()
     }
 
@@ -85,13 +85,13 @@ open class JXSegmentedBaseDataSource: JXSegmentedViewDataSource {
         if index == selectedIndex {
             itemModel.isSelected = true
             itemModel.itemWidthCurrentZoomScale = itemModel.itemWidthSelectedZoomScale
-        }else {
+        } else {
             itemModel.isSelected = false
             itemModel.itemWidthCurrentZoomScale = itemModel.itemWidthNormalZoomScale
         }
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open func itemDataSource(in segmentedView: JXSegmentedView) -> [JXSegmentedBaseItemModel] {
         return dataSource
     }
@@ -133,18 +133,18 @@ open class JXSegmentedBaseDataSource: JXSegmentedViewDataSource {
                 }
                 animator?.start()
             }
-        }else {
+        } else {
             currentSelectedItemModel.itemWidthCurrentZoomScale = currentSelectedItemModel.itemWidthNormalZoomScale
             willSelectedItemModel.itemWidthCurrentZoomScale = willSelectedItemModel.itemWidthSelectedZoomScale
         }
     }
 
     open func refreshItemModel(_ segmentedView: JXSegmentedView, leftItemModel: JXSegmentedBaseItemModel, rightItemModel: JXSegmentedBaseItemModel, percent: CGFloat) {
-        //如果正在进行itemWidth缩放动画，用户又立马滚动了contentScrollView，需要停止动画。
+        // 如果正在进行itemWidth缩放动画，用户又立马滚动了contentScrollView，需要停止动画。
         animator?.stop()
         animator = nil
         if isItemWidthZoomEnabled && isItemTransitionEnabled {
-            //允许itemWidth缩放动画且允许item渐变过渡
+            // 允许itemWidth缩放动画且允许item渐变过渡
             leftItemModel.itemWidthCurrentZoomScale = JXSegmentedViewTool.interpolate(from: leftItemModel.itemWidthSelectedZoomScale, to: leftItemModel.itemWidthNormalZoomScale, percent: percent)
             leftItemModel.itemWidth = itemWidthWithZoom(at: leftItemModel.index, model: leftItemModel)
             rightItemModel.itemWidthCurrentZoomScale = JXSegmentedViewTool.interpolate(from: rightItemModel.itemWidthNormalZoomScale, to: rightItemModel.itemWidthSelectedZoomScale, percent: percent)

--- a/Sources/Core/JXSegmentedView.swift
+++ b/Sources/Core/JXSegmentedView.swift
@@ -24,7 +24,7 @@ public enum JXSegmentedViewItemSelectedType {
 }
 
 public protocol JXSegmentedViewListContainer {
-    var defaultSelectedIndex: Int { set get }
+    var defaultSelectedIndex: Int { get set }
     func contentScrollView() -> UIScrollView
     func reloadData()
     func didClickSelectedItem(at index: Int)
@@ -127,7 +127,6 @@ public protocol JXSegmentedViewDelegate: AnyObject {
     ///   - rightIndex: 正在滚动中，相对位置处于右边的index
     ///   - percent: 从左往右计算的百分比
     func segmentedView(_ segmentedView: JXSegmentedView, scrollingFrom leftIndex: Int, to rightIndex: Int, percent: CGFloat)
-
 
     /// 是否允许点击选中目标index的item
     ///
@@ -244,7 +243,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
 
         var nextResponder: UIResponder? = newSuperview
         while nextResponder != nil {
-            if let parentVC = nextResponder as? UIViewController  {
+            if let parentVC = nextResponder as? UIViewController {
                 parentVC.automaticallyAdjustsScrollViewInsets = false
                 break
             }
@@ -255,14 +254,14 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        //部分使用者为了适配不同的手机屏幕尺寸，JXSegmentedView的宽高比要求保持一样。所以它的高度就会因为不同宽度的屏幕而不一样。计算出来的高度，有时候会是位数很长的浮点数，如果把这个高度设置给UICollectionView就会触发内部的一个错误。所以，为了规避这个问题，在这里对高度统一向下取整。
-        //如果向下取整导致了你的页面异常，请自己重新设置JXSegmentedView的高度，保证为整数即可。
+        // 部分使用者为了适配不同的手机屏幕尺寸，JXSegmentedView的宽高比要求保持一样。所以它的高度就会因为不同宽度的屏幕而不一样。计算出来的高度，有时候会是位数很长的浮点数，如果把这个高度设置给UICollectionView就会触发内部的一个错误。所以，为了规避这个问题，在这里对高度统一向下取整。
+        // 如果向下取整导致了你的页面异常，请自己重新设置JXSegmentedView的高度，保证为整数即可。
         let targetFrame = CGRect(x: 0, y: 0, width: bounds.size.width, height: floor(bounds.size.height))
         if isFirstLayoutSubviews {
             isFirstLayoutSubviews = false
             collectionView.frame = targetFrame
             reloadDataWithoutListContainer()
-        }else {
+        } else {
             if collectionView.frame != targetFrame {
                 collectionView.frame = targetFrame
                 collectionView.collectionViewLayout.invalidateLayout()
@@ -271,7 +270,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         }
     }
 
-    //MARK: - Public
+    // MARK: - Public
     public final func dequeueReusableCell(withReuseIdentifier identifier: String, at index: Int) -> JXSegmentedBaseCell {
         let indexPath = IndexPath(item: index, section: 0)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
@@ -310,7 +309,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
             totalItemWidth += itemModel.itemWidth
             if index == itemDataSource.count - 1 {
                 totalContentWidth += itemModel.itemWidth + getContentEdgeInsetRight()
-            }else {
+            } else {
                 totalContentWidth += itemModel.itemWidth + innerItemSpacing
             }
         }
@@ -320,12 +319,12 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
             var totalItemSpacingWidth = bounds.size.width - totalItemWidth
             if contentEdgeInsetLeft == JXSegmentedViewAutomaticDimension {
                 itemSpacingCount += 1
-            }else {
+            } else {
                 totalItemSpacingWidth -= contentEdgeInsetLeft
             }
             if contentEdgeInsetRight == JXSegmentedViewAutomaticDimension {
                 itemSpacingCount += 1
-            }else {
+            } else {
                 totalItemSpacingWidth -= contentEdgeInsetRight
             }
             if itemSpacingCount > 0 {
@@ -339,12 +338,12 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         for (index, itemModel) in itemDataSource.enumerated() {
             if index < selectedIndex {
                 selectedItemFrameX += itemModel.itemWidth + innerItemSpacing
-            }else if index == selectedIndex {
+            } else if index == selectedIndex {
                 selectedItemWidth = itemModel.itemWidth
             }
             if index == itemDataSource.count - 1 {
                 totalContentWidth += itemModel.itemWidth + getContentEdgeInsetRight()
-            }else {
+            } else {
                 totalContentWidth += itemModel.itemWidth + innerItemSpacing
             }
         }
@@ -357,8 +356,8 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         if contentScrollView != nil {
             if contentScrollView!.frame.equalTo(CGRect.zero) &&
                 contentScrollView!.superview != nil {
-                //某些情况系统会出现JXSegmentedView先布局，contentScrollView后布局。就会导致下面指定defaultSelectedIndex失效，所以发现contentScrollView的frame为zero时，强行触发其父视图链里面已经有frame的一个父视图的layoutSubviews方法。
-                //比如JXSegmentedListContainerView会将contentScrollView包裹起来使用，该情况需要JXSegmentedListContainerView.superView触发布局更新
+                // 某些情况系统会出现JXSegmentedView先布局，contentScrollView后布局。就会导致下面指定defaultSelectedIndex失效，所以发现contentScrollView的frame为zero时，强行触发其父视图链里面已经有frame的一个父视图的layoutSubviews方法。
+                // 比如JXSegmentedListContainerView会将contentScrollView包裹起来使用，该情况需要JXSegmentedListContainerView.superView触发布局更新
                 var parentView = contentScrollView?.superview
                 while parentView != nil && parentView?.frame.equalTo(CGRect.zero) == true {
                     parentView = parentView?.superview
@@ -367,14 +366,13 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
                 parentView?.layoutIfNeeded()
             }
 
-            contentScrollView!.setContentOffset(CGPoint(x: CGFloat(selectedIndex) * contentScrollView!.bounds.size.width
-                , y: 0), animated: false)
+            contentScrollView!.setContentOffset(CGPoint(x: CGFloat(selectedIndex) * contentScrollView!.bounds.size.width, y: 0), animated: false)
         }
 
         for indicator in indicators {
             if itemDataSource.isEmpty {
                 indicator.isHidden = true
-            }else {
+            } else {
                 indicator.isHidden = false
                 let selectedItemFrame = getItemFrameAt(index: selectedIndex)
                 let indicatorParams = JXSegmentedIndicatorSelectedParams(currentSelectedIndex: selectedIndex,
@@ -405,7 +403,6 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         cell?.reloadData(itemModel: itemDataSource[index], selectedType: .unknown)
     }
 
-
     /// 代码选中指定index
     /// 如果要同时触发列表容器对应index的列表加载，请再调用`listContainerView.didClickSelectedItem(at: index)`方法
     ///
@@ -414,28 +411,28 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         selectItemAt(index: index, selectedType: .code)
     }
 
-    //MARK: - KVO
-    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    // MARK: - KVO
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == "contentOffset" {
             let contentOffset = change?[NSKeyValueChangeKey.newKey] as! CGPoint
             if contentScrollView?.isTracking == true || contentScrollView?.isDecelerating == true {
-                //用户滚动引起的contentOffset变化，才处理。
+                // 用户滚动引起的contentOffset变化，才处理。
                 if contentScrollView?.bounds.size.width == 0 {
                     // 如果contentScrollView Frame为零，直接忽略
                     return
                 }
                 var progress = contentOffset.x/contentScrollView!.bounds.size.width
                 if Int(progress) > itemDataSource.count - 1 || progress < 0 {
-                    //超过了边界，不需要处理
+                    // 超过了边界，不需要处理
                     return
                 }
                 if contentOffset.x == 0 && selectedIndex == 0 && lastContentOffset.x == 0 {
-                    //滚动到了最左边，且已经选中了第一个，且之前的contentOffset.x为0
+                    // 滚动到了最左边，且已经选中了第一个，且之前的contentOffset.x为0
                     return
                 }
                 let maxContentOffsetX = contentScrollView!.contentSize.width - contentScrollView!.bounds.size.width
                 if contentOffset.x == maxContentOffsetX && selectedIndex == itemDataSource.count - 1 && lastContentOffset.x == maxContentOffsetX {
-                    //滚动到了最右边，且已经选中了最后一个，且之前的contentOffset.x为maxContentOffsetX
+                    // 滚动到了最右边，且已经选中了最后一个，且之前的contentOffset.x为maxContentOffsetX
                     return
                 }
 
@@ -459,13 +456,13 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
                                                                            percent: remainderProgress)
 
                 if remainderProgress == 0 {
-                    //滑动翻页，需要更新选中状态
-                    //滑动一小段距离，然后放开回到原位，contentOffset同样的值会回调多次。例如在index为1的情况，滑动放开回到原位，contentOffset会多次回调CGPoint(width, 0)
+                    // 滑动翻页，需要更新选中状态
+                    // 滑动一小段距离，然后放开回到原位，contentOffset同样的值会回调多次。例如在index为1的情况，滑动放开回到原位，contentOffset会多次回调CGPoint(width, 0)
                     if !(lastContentOffset.x == contentOffset.x && selectedIndex == baseIndex) {
                         scrollSelectItemAt(index: baseIndex)
                     }
-                }else {
-                    //快速滑动翻页，当remainderRatio没有变成0，但是已经翻页了，需要通过下面的判断，触发选中
+                } else {
+                    // 快速滑动翻页，当remainderRatio没有变成0，但是已经翻页了，需要通过下面的判断，触发选中
                     if abs(progress - CGFloat(selectedIndex)) > 1 {
                         var targetIndex = baseIndex
                         if progress < CGFloat(selectedIndex) {
@@ -475,7 +472,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
                     }
                     if selectedIndex == baseIndex {
                         scrollingTargetIndex = baseIndex + 1
-                    }else {
+                    } else {
                         scrollingTargetIndex = baseIndex
                     }
 
@@ -507,7 +504,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         }
     }
 
-    //MARK: - Private
+    // MARK: - Private
     private func clickSelectItemAt(index: Int) {
         guard delegate?.segmentedView(self, canClickItemAt: index) != false else {
             return
@@ -527,10 +524,10 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         if index == selectedIndex {
             if selectedType == .code {
                 listContainer?.didClickSelectedItem(at: index)
-            }else if selectedType == .click {
+            } else if selectedType == .click {
                 delegate?.segmentedView(self, didClickSelectedItemAt: index)
                 listContainer?.didClickSelectedItem(at: index)
-            }else if selectedType == .scroll {
+            } else if selectedType == .scroll {
                 delegate?.segmentedView(self, didScrollSelectedItemAt: index)
             }
             delegate?.segmentedView(self, didSelectedItemAt: index)
@@ -558,16 +555,16 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
 
         if dataSource?.isItemWidthZoomEnabled == true {
             if selectedType == .click || selectedType == .code {
-                //延时为了解决cellwidth变化，点击最后几个cell，scrollToItem会出现位置偏移bu。需要等cellWidth动画渐变结束后再滚动到index的cell位置。
+                // 延时为了解决cellwidth变化，点击最后几个cell，scrollToItem会出现位置偏移bu。需要等cellWidth动画渐变结束后再滚动到index的cell位置。
                 let selectedAnimationDurationInMilliseconds = Int((dataSource?.selectedAnimationDuration ?? 0)*1000)
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(selectedAnimationDurationInMilliseconds)) {
                     self.collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: true)
                 }
-            }else if selectedType == .scroll {
-                //滚动选中的直接处理
+            } else if selectedType == .scroll {
+                // 滚动选中的直接处理
                 collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: true)
             }
-        }else {
+        } else {
             collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: true)
         }
 
@@ -597,10 +594,10 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         scrollingTargetIndex = -1
         if selectedType == .code {
             listContainer?.didClickSelectedItem(at: index)
-        }else if selectedType == .click {
+        } else if selectedType == .click {
             delegate?.segmentedView(self, didClickSelectedItemAt: index)
             listContainer?.didClickSelectedItem(at: index)
-        }else if selectedType == .scroll {
+        } else if selectedType == .scroll {
             delegate?.segmentedView(self, didScrollSelectedItemAt: index)
         }
         delegate?.segmentedView(self, didSelectedItemAt: index)
@@ -615,13 +612,13 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
             let itemModel = itemDataSource[i]
             var itemWidth: CGFloat = 0
             if itemModel.isTransitionAnimating && itemModel.isItemWidthZoomEnabled {
-                //正在进行动画的时候，itemWidthCurrentZoomScale是随着动画渐变的，而没有立即更新到目标值
+                // 正在进行动画的时候，itemWidthCurrentZoomScale是随着动画渐变的，而没有立即更新到目标值
                 if itemModel.isSelected {
                     itemWidth = (dataSource?.segmentedView(self, widthForItemAt: itemModel.index) ?? 0) * itemModel.itemWidthSelectedZoomScale
-                }else {
+                } else {
                     itemWidth = (dataSource?.segmentedView(self, widthForItemAt: itemModel.index) ?? 0) * itemModel.itemWidthNormalZoomScale
                 }
-            }else {
+            } else {
                 itemWidth = itemModel.itemWidth
             }
             x += itemWidth + innerItemSpacing
@@ -630,7 +627,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         let selectedItemModel = itemDataSource[index]
         if selectedItemModel.isTransitionAnimating && selectedItemModel.isItemWidthZoomEnabled {
             width = (dataSource?.segmentedView(self, widthForItemAt: selectedItemModel.index) ?? 0) * selectedItemModel.itemWidthSelectedZoomScale
-        }else {
+        } else {
             width = selectedItemModel.itemWidth
         }
         return CGRect(x: x, y: 0, width: width, height: bounds.size.height)
@@ -649,7 +646,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
         let selectedItemModel = itemDataSource[index]
         if selectedItemModel.isItemWidthZoomEnabled {
             width = (dataSource?.segmentedView(self, widthForItemAt: selectedItemModel.index) ?? 0) * selectedItemModel.itemWidthSelectedZoomScale
-        }else {
+        } else {
             width = selectedItemModel.itemWidth
         }
         return CGRect(x: x, y: 0, width: width, height: bounds.size.height)
@@ -658,7 +655,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
     private func getContentEdgeInsetLeft() -> CGFloat {
         if contentEdgeInsetLeft == JXSegmentedViewAutomaticDimension {
             return innerItemSpacing
-        }else {
+        } else {
             return contentEdgeInsetLeft
         }
     }
@@ -666,7 +663,7 @@ open class JXSegmentedView: UIView, JXSegmentedViewRTLCompatible {
     private func getContentEdgeInsetRight() -> CGFloat {
         if contentEdgeInsetRight == JXSegmentedViewAutomaticDimension {
             return innerItemSpacing
-        }else {
+        } else {
             return contentEdgeInsetRight
         }
     }
@@ -685,7 +682,7 @@ extension JXSegmentedView: UICollectionViewDataSource {
         if let cell = dataSource?.segmentedView(self, cellForItemAt: indexPath.item) {
             cell.reloadData(itemModel: itemDataSource[indexPath.item], selectedType: .unknown)
             return cell
-        }else {
+        } else {
             return UICollectionViewCell(frame: CGRect.zero)
         }
     }
@@ -701,7 +698,7 @@ extension JXSegmentedView: UICollectionViewDelegate {
             }
         }
         if !isTransitionAnimating {
-            //当前没有正在过渡的item，才允许点击选中
+            // 当前没有正在过渡的item，才允许点击选中
             clickSelectItemAt(index: indexPath.item)
         }
     }

--- a/Sources/Dot/JXSegmentedDotDataSource.swift
+++ b/Sources/Dot/JXSegmentedDotDataSource.swift
@@ -37,12 +37,12 @@ open class JXSegmentedDotDataSource: JXSegmentedTitleDataSource {
         itemModel.dotSize = dotSize
         if dotCornerRadius == JXSegmentedViewAutomaticDimension {
             itemModel.dotCornerRadius = dotSize.height/2
-        }else {
+        } else {
             itemModel.dotCornerRadius = dotCornerRadius
         }
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedDotCell.self, forCellWithReuseIdentifier: "cell")
     }

--- a/Sources/Indicator/JXSegmentedIndicatorBackgroundView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorBackgroundView.swift
@@ -85,7 +85,7 @@ open class JXSegmentedIndicatorBackgroundView: JXSegmentedIndicatorBaseView {
                 self.frame = toFrame
             }) { (_) in
             }
-        }else {
+        } else {
             frame = toFrame
         }
     }

--- a/Sources/Indicator/JXSegmentedIndicatorBaseView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorBaseView.swift
@@ -17,7 +17,7 @@ public enum JXSegmentedIndicatorPosition {
 open class JXSegmentedIndicatorBaseView: UIView, JXSegmentedIndicatorProtocol {
     /// 默认JXSegmentedViewAutomaticDimension（与cell的宽度相等）。内部通过getIndicatorWidth方法获取实际的值
     open var indicatorWidth: CGFloat = JXSegmentedViewAutomaticDimension
-    open var indicatorWidthIncrement: CGFloat = 0   //指示器的宽度增量。比如需求是指示器宽度比cell宽度多10 point。就可以将该属性赋值为10。最终指示器的宽度=indicatorWidth+indicatorWidthIncrement
+    open var indicatorWidthIncrement: CGFloat = 0   // 指示器的宽度增量。比如需求是指示器宽度比cell宽度多10 point。就可以将该属性赋值为10。最终指示器的宽度=indicatorWidth+indicatorWidthIncrement
     /// 默认JXSegmentedViewAutomaticDimension（与cell的高度相等）。内部通过getIndicatorHeight方法获取实际的值
     open var indicatorHeight: CGFloat = JXSegmentedViewAutomaticDimension
     /// 默认JXSegmentedViewAutomaticDimension （等于indicatorHeight/2）。内部通过getIndicatorCornerRadius方法获取实际的值
@@ -65,7 +65,7 @@ open class JXSegmentedIndicatorBaseView: UIView, JXSegmentedIndicatorProtocol {
         if indicatorWidth == JXSegmentedViewAutomaticDimension {
             if isIndicatorWidthSameAsItemContent {
                 return itemContentWidth + indicatorWidthIncrement
-            }else {
+            } else {
                 return itemFrame.size.width + indicatorWidthIncrement
             }
         }
@@ -81,8 +81,8 @@ open class JXSegmentedIndicatorBaseView: UIView, JXSegmentedIndicatorProtocol {
 
     public func canHandleTransition(model: JXSegmentedIndicatorTransitionParams) -> Bool {
         if model.percent == 0 || !isScrollEnabled {
-            //model.percent等于0时不需要处理，会调用selectItem(model: JXSegmentedIndicatorParamsModel)方法处理
-            //isScrollEnabled为false不需要处理
+            // model.percent等于0时不需要处理，会调用selectItem(model: JXSegmentedIndicatorParamsModel)方法处理
+            // isScrollEnabled为false不需要处理
             return false
         }
         return true
@@ -90,13 +90,13 @@ open class JXSegmentedIndicatorBaseView: UIView, JXSegmentedIndicatorProtocol {
 
     public func canSelectedWithAnimation(model: JXSegmentedIndicatorSelectedParams) -> Bool {
         if isScrollEnabled && (model.selectedType == .click || model.selectedType == .code) {
-            //允许滚动且选中类型是点击或代码选中，才进行动画过渡
+            // 允许滚动且选中类型是点击或代码选中，才进行动画过渡
             return true
         }
         return false
     }
 
-    //MARK: - JXSegmentedIndicatorProtocol
+    // MARK: - JXSegmentedIndicatorProtocol
     open func refreshIndicatorState(model: JXSegmentedIndicatorSelectedParams) {
     }
 

--- a/Sources/Indicator/JXSegmentedIndicatorDotLineView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorDotLineView.swift
@@ -15,7 +15,7 @@ open class JXSegmentedIndicatorDotLineView: JXSegmentedIndicatorBaseView {
     open override func commonInit() {
         super.commonInit()
 
-        //配置点的size
+        // 配置点的size
         indicatorWidth = 10
         indicatorHeight = 10
     }
@@ -61,11 +61,11 @@ open class JXSegmentedIndicatorDotLineView: JXSegmentedIndicatorBaseView {
         let rightX = rightItemFrame.origin.x + (rightItemFrame.size.width - rightWidth)/2
         let centerX = leftX + (rightX - leftX - lineMaxWidth)/2
 
-        //前50%，移动x，增加宽度；后50%，移动x并减小width
+        // 前50%，移动x，增加宽度；后50%，移动x并减小width
         if percent <= 0.5 {
             targetX = JXSegmentedViewTool.interpolate(from: leftX, to: centerX, percent: CGFloat(percent*2))
             targetWidth = JXSegmentedViewTool.interpolate(from: dotWidth, to: lineMaxWidth, percent: CGFloat(percent*2))
-        }else {
+        } else {
             targetX = JXSegmentedViewTool.interpolate(from: centerX, to: rightX, percent: CGFloat((percent - 0.5)*2))
             targetWidth = JXSegmentedViewTool.interpolate(from: lineMaxWidth, to: dotWidth, percent: CGFloat((percent - 0.5)*2))
         }
@@ -86,7 +86,7 @@ open class JXSegmentedIndicatorDotLineView: JXSegmentedIndicatorBaseView {
                 self.frame = toFrame
             }) { (_) in
             }
-        }else {
+        } else {
             frame = toFrame
         }
     }

--- a/Sources/Indicator/JXSegmentedIndicatorDoubleLineView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorDoubleLineView.swift
@@ -80,7 +80,7 @@ open class JXSegmentedIndicatorDoubleLineView: JXSegmentedIndicatorBaseView {
             otherLineView.bounds.size.width = rightWidth
             otherLineView.center = rightCenter
             otherLineView.alpha = rightAlpha
-        }else {
+        } else {
             otherLineView.bounds.size.width = leftWidth
             otherLineView.center = leftCenter
             otherLineView.alpha = leftAlpha

--- a/Sources/Indicator/JXSegmentedIndicatorGradientView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorGradientView.swift
@@ -28,7 +28,7 @@ open class JXSegmentedIndicatorGradientView: JXSegmentedIndicatorBaseView {
     open class override var layerClass: AnyClass {
         return CAGradientLayer.self
     }
-    
+
     private var gradientMaskLayerFrame = CGRect.zero
 
     open override func commonInit() {
@@ -121,7 +121,7 @@ open class JXSegmentedIndicatorGradientView: JXSegmentedIndicatorBaseView {
             animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
             gradientMaskLayer.add(animation, forKey: "path")
             gradientMaskLayer.path = path.cgPath
-        }else {
+        } else {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             gradientMaskLayer.path = path.cgPath

--- a/Sources/Indicator/JXSegmentedIndicatorImageView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorImageView.swift
@@ -58,7 +58,7 @@ open class JXSegmentedIndicatorImageView: JXSegmentedIndicatorBaseView {
         let leftX = leftItemFrame.origin.x + (leftItemFrame.size.width - targetWidth)/2
         let rightX = rightItemFrame.origin.x + (rightItemFrame.size.width - targetWidth)/2
         let targetX = JXSegmentedViewTool.interpolate(from: leftX, to: rightX, percent: CGFloat(percent))
-        
+
         self.frame.origin.x = targetX
     }
 
@@ -73,7 +73,7 @@ open class JXSegmentedIndicatorImageView: JXSegmentedIndicatorBaseView {
                 self.frame = toFrame
             }) { (_) in
             }
-        }else {
+        } else {
             frame = toFrame
         }
     }

--- a/Sources/Indicator/JXSegmentedIndicatorLineView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorLineView.swift
@@ -71,23 +71,23 @@ open class JXSegmentedIndicatorLineView: JXSegmentedIndicatorBaseView {
                 targetWidth = JXSegmentedViewTool.interpolate(from: leftWidth, to: rightWidth, percent: CGFloat(percent))
             }
         case .lengthen:
-            //前50%，只增加width；后50%，移动x并减小width
+            // 前50%，只增加width；后50%，移动x并减小width
             let maxWidth = rightX - leftX + rightWidth
             if percent <= 0.5 {
                 targetX = leftX
                 targetWidth = JXSegmentedViewTool.interpolate(from: leftWidth, to: maxWidth, percent: CGFloat(percent*2))
-            }else {
+            } else {
                 targetX = JXSegmentedViewTool.interpolate(from: leftX, to: rightX, percent: CGFloat((percent - 0.5)*2))
                 targetWidth = JXSegmentedViewTool.interpolate(from: maxWidth, to: rightWidth, percent: CGFloat((percent - 0.5)*2))
             }
         case .lengthenOffset:
-            //前50%，增加width，并少量移动x；后50%，少量移动x并减小width
+            // 前50%，增加width，并少量移动x；后50%，少量移动x并减小width
             let maxWidth = rightX - leftX + rightWidth - lineScrollOffsetX*2
             if percent <= 0.5 {
                 targetX = JXSegmentedViewTool.interpolate(from: leftX, to: leftX + lineScrollOffsetX, percent: CGFloat(percent*2))
                 targetWidth = JXSegmentedViewTool.interpolate(from: leftWidth, to: maxWidth, percent: CGFloat(percent*2))
-            }else {
-                targetX = JXSegmentedViewTool.interpolate(from:leftX + lineScrollOffsetX, to: rightX, percent: CGFloat((percent - 0.5)*2))
+            } else {
+                targetX = JXSegmentedViewTool.interpolate(from: leftX + lineScrollOffsetX, to: rightX, percent: CGFloat((percent - 0.5)*2))
                 targetWidth = JXSegmentedViewTool.interpolate(from: maxWidth, to: rightWidth, percent: CGFloat((percent - 0.5)*2))
             }
         }
@@ -108,7 +108,7 @@ open class JXSegmentedIndicatorLineView: JXSegmentedIndicatorBaseView {
                 self.frame = toFrame
             }) { (_) in
             }
-        }else {
+        } else {
             frame = toFrame
         }
     }

--- a/Sources/Indicator/JXSegmentedIndicatorProtocol.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorProtocol.swift
@@ -14,7 +14,7 @@ public protocol JXSegmentedIndicatorProtocol {
     /// 如果添加了多个indicator，仅能有一个indicator的isIndicatorConvertToItemFrameEnabled为true。
     /// 如果有多个indicator的isIndicatorConvertToItemFrameEnabled为true，则以最后一个isIndicatorConvertToItemFrameEnabled为true的indicator为准。
     var isIndicatorConvertToItemFrameEnabled: Bool { get }
-    
+
     /// 视图重置状态时调用，已当前选中的index更新状态
     /// param selectedIndex 当前选中的index
     /// param selectedCellFrame 当前选中的cellFrame

--- a/Sources/Indicator/JXSegmentedIndicatorRainbowLineView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorRainbowLineView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 /// 会无视indicatorColor属性，以indicatorColors为准
 open class JXSegmentedIndicatorRainbowLineView: JXSegmentedIndicatorLineView {
     /// 数量需要与item的数量相等。默认空数组，必须要赋值该属性。segmentedView在reloadData的时候，也要一并更新该属性，不然会出现数组越界。

--- a/Sources/Indicator/JXSegmentedIndicatorTriangleView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorTriangleView.swift
@@ -48,7 +48,7 @@ open class JXSegmentedIndicatorTriangleView: JXSegmentedIndicatorBaseView {
             path.move(to: CGPoint(x: 0, y: height))
             path.addLine(to: CGPoint(x: width/2, y: 0))
             path.addLine(to: CGPoint(x: width, y: height))
-        }else {
+        } else {
             path.move(to: CGPoint(x: 0, y: 0))
             path.addLine(to: CGPoint(x: width/2, y: height))
             path.addLine(to: CGPoint(x: width, y: 0))
@@ -88,7 +88,7 @@ open class JXSegmentedIndicatorTriangleView: JXSegmentedIndicatorBaseView {
                 self.frame = toFrame
             }) { (_) in
             }
-        }else {
+        } else {
             frame = toFrame
         }
     }

--- a/Sources/Number/JXSegmentedNumberDataSource.swift
+++ b/Sources/Number/JXSegmentedNumberDataSource.swift
@@ -41,7 +41,7 @@ open class JXSegmentedNumberDataSource: JXSegmentedTitleDataSource {
         itemModel.number = numbers[index]
         if numberStringFormatterClosure != nil {
             itemModel.numberString = numberStringFormatterClosure!(itemModel.number)
-        }else {
+        } else {
             itemModel.numberString = "\(itemModel.number)"
         }
         itemModel.numberTextColor = numberTextColor
@@ -51,7 +51,7 @@ open class JXSegmentedNumberDataSource: JXSegmentedTitleDataSource {
         itemModel.numberHeight = numberHeight
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedNumberCell.self, forCellWithReuseIdentifier: "cell")
     }

--- a/Sources/Title/JXSegmentedTitleCell.swift
+++ b/Sources/Title/JXSegmentedTitleCell.swift
@@ -33,7 +33,7 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        //为什么使用`sizeThatFits`，而不用`sizeToFit`呢？在numberOfLines大于0的时候，cell进行重用的时候通过`sizeToFit`，label设置成错误的size。至于原因我用尽毕生所学，没有找到为什么。但是用`sizeThatFits`可以规避掉这个问题。
+        // 为什么使用`sizeThatFits`，而不用`sizeToFit`呢？在numberOfLines大于0的时候，cell进行重用的时候通过`sizeToFit`，label设置成错误的size。至于原因我用尽毕生所学，没有找到为什么。但是用`sizeThatFits`可以规避掉这个问题。
         let labelSize = titleLabel.sizeThatFits(self.contentView.bounds.size)
         let labelBounds = CGRect(x: 0, y: 0, width: labelSize.width, height: labelSize.height)
         titleLabel.bounds = labelBounds
@@ -54,26 +54,26 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
         maskTitleLabel.numberOfLines = myItemModel.titleNumberOfLines
 
         if myItemModel.isTitleZoomEnabled {
-            //先把font设置为缩放的最大值，再缩小到最小值，最后根据当前的titleCurrentZoomScale值，进行缩放更新。这样就能避免transform从小到大时字体模糊
+            // 先把font设置为缩放的最大值，再缩小到最小值，最后根据当前的titleCurrentZoomScale值，进行缩放更新。这样就能避免transform从小到大时字体模糊
             let maxScaleFont = UIFont(descriptor: myItemModel.titleNormalFont.fontDescriptor, size: myItemModel.titleNormalFont.pointSize*CGFloat(myItemModel.titleSelectedZoomScale))
             let baseScale = myItemModel.titleNormalFont.lineHeight/maxScaleFont.lineHeight
 
             if myItemModel.isSelectedAnimable && canStartSelectedAnimation(itemModel: itemModel, selectedType: selectedType) {
-                //允许动画且当前是点击的
+                // 允许动画且当前是点击的
                 let titleZoomClosure = preferredTitleZoomAnimateClosure(itemModel: myItemModel, baseScale: baseScale)
                 appendSelectedAnimationClosure(closure: titleZoomClosure)
-            }else {
+            } else {
                 titleLabel.font = maxScaleFont
                 maskTitleLabel.font = maxScaleFont
                 let currentTransform = CGAffineTransform(scaleX: baseScale*CGFloat(myItemModel.titleCurrentZoomScale), y: baseScale*CGFloat(myItemModel.titleCurrentZoomScale))
                 titleLabel.transform = currentTransform
                 maskTitleLabel.transform = currentTransform
             }
-        }else {
+        } else {
             if myItemModel.isSelected {
                 titleLabel.font = myItemModel.titleSelectedFont
                 maskTitleLabel.font = myItemModel.titleSelectedFont
-            }else {
+            } else {
                 titleLabel.font = myItemModel.titleNormalFont
                 maskTitleLabel.font = myItemModel.titleNormalFont
             }
@@ -83,22 +83,22 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
         let attriText = NSMutableAttributedString(string: title)
         if myItemModel.isTitleStrokeWidthEnabled {
             if myItemModel.isSelectedAnimable && canStartSelectedAnimation(itemModel: itemModel, selectedType: selectedType) {
-                //允许动画且当前是点击的
+                // 允许动画且当前是点击的
                 let titleStrokeWidthClosure = preferredTitleStrokeWidthAnimateClosure(itemModel: myItemModel, attriText: attriText)
                 appendSelectedAnimationClosure(closure: titleStrokeWidthClosure)
-            }else {
+            } else {
                 attriText.addAttributes([NSAttributedString.Key.strokeWidth: myItemModel.titleCurrentStrokeWidth], range: NSRange(location: 0, length: title.count))
                 titleLabel.attributedText = attriText
                 maskTitleLabel.attributedText = attriText
             }
-        }else {
+        } else {
             titleLabel.attributedText = attriText
             maskTitleLabel.attributedText = attriText
         }
 
         if myItemModel.isTitleMaskEnabled {
-            //允许mask，maskTitleLabel在titleLabel上面，maskTitleLabel设置为titleSelectedColor。titleLabel设置为titleNormalColor
-            //为了显示效果，使用了双遮罩。即titleMaskLayer遮罩titleLabel，maskTitleMaskLayer遮罩maskTitleLabel
+            // 允许mask，maskTitleLabel在titleLabel上面，maskTitleLabel设置为titleSelectedColor。titleLabel设置为titleNormalColor
+            // 为了显示效果，使用了双遮罩。即titleMaskLayer遮罩titleLabel，maskTitleMaskLayer遮罩maskTitleLabel
             maskTitleLabel.isHidden = false
             titleLabel.textColor = myItemModel.titleNormalColor
             maskTitleLabel.textColor = myItemModel.titleSelectedColor
@@ -114,7 +114,7 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
                 topMaskFrame.origin.x -= (maskTitleLabel.bounds.size.width - bounds.size.width)/2
                 bottomMaskFrame.size.width = maskTitleLabel.bounds.size.width
                 maskStartX = -(maskTitleLabel.bounds.size.width - bounds.size.width)/2
-            }else {
+            } else {
                 topMaskFrame.origin.x -= (bounds.size.width - maskTitleLabel.bounds.size.width)/2
                 bottomMaskFrame.size.width = bounds.size.width
                 maskStartX = 0
@@ -122,7 +122,7 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
             bottomMaskFrame.origin.x = topMaskFrame.origin.x
             if topMaskFrame.origin.x > maskStartX {
                 bottomMaskFrame.origin.x = topMaskFrame.origin.x - bottomMaskFrame.size.width
-            }else {
+            } else {
                 bottomMaskFrame.origin.x = topMaskFrame.maxX
             }
 
@@ -132,19 +132,19 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
                 titleLabel.layer.mask = titleMaskLayer
                 titleMaskLayer.frame = bottomMaskFrame
                 maskTitleMaskLayer.frame = topMaskFrame
-            }else {
+            } else {
                 titleLabel.layer.mask = nil
                 maskTitleMaskLayer.frame = topMaskFrame
             }
             CATransaction.commit()
-        }else {
+        } else {
             maskTitleLabel.isHidden = true
             titleLabel.layer.mask = nil
             if myItemModel.isSelectedAnimable && canStartSelectedAnimation(itemModel: itemModel, selectedType: selectedType) {
-                //允许动画且当前是点击的
+                // 允许动画且当前是点击的
                 let titleColorClosure = preferredTitleColorAnimateClosure(itemModel: myItemModel)
                 appendSelectedAnimationClosure(closure: titleColorClosure)
-            }else {
+            } else {
                 titleLabel.textColor = myItemModel.titleCurrentColor
             }
         }
@@ -157,11 +157,11 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
     open func preferredTitleZoomAnimateClosure(itemModel: JXSegmentedTitleItemModel, baseScale: CGFloat) -> JXSegmentedCellSelectedAnimationClosure {
         return {[weak self] (percnet) in
             if itemModel.isSelected {
-                //将要选中，scale从小到大插值渐变
+                // 将要选中，scale从小到大插值渐变
                 itemModel.titleCurrentZoomScale = JXSegmentedViewTool.interpolate(from: itemModel.titleNormalZoomScale, to: itemModel.titleSelectedZoomScale, percent: percnet)
-            }else {
-                //将要取消选中，scale从大到小插值渐变
-                itemModel.titleCurrentZoomScale = JXSegmentedViewTool.interpolate(from: itemModel.titleSelectedZoomScale, to:itemModel.titleNormalZoomScale , percent: percnet)
+            } else {
+                // 将要取消选中，scale从大到小插值渐变
+                itemModel.titleCurrentZoomScale = JXSegmentedViewTool.interpolate(from: itemModel.titleSelectedZoomScale, to: itemModel.titleNormalZoomScale, percent: percnet)
             }
             let currentTransform = CGAffineTransform(scaleX: baseScale*itemModel.titleCurrentZoomScale, y: baseScale*itemModel.titleCurrentZoomScale)
             self?.titleLabel.transform = currentTransform
@@ -169,14 +169,14 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
         }
     }
 
-    open func preferredTitleStrokeWidthAnimateClosure(itemModel: JXSegmentedTitleItemModel, attriText: NSMutableAttributedString) -> JXSegmentedCellSelectedAnimationClosure{
+    open func preferredTitleStrokeWidthAnimateClosure(itemModel: JXSegmentedTitleItemModel, attriText: NSMutableAttributedString) -> JXSegmentedCellSelectedAnimationClosure {
         return {[weak self] (percent) in
             if itemModel.isSelected {
-                //将要选中，StrokeWidth从小到大插值渐变
+                // 将要选中，StrokeWidth从小到大插值渐变
                 itemModel.titleCurrentStrokeWidth = JXSegmentedViewTool.interpolate(from: itemModel.titleNormalStrokeWidth, to: itemModel.titleSelectedStrokeWidth, percent: percent)
-            }else {
-                //将要取消选中，StrokeWidth从大到小插值渐变
-                itemModel.titleCurrentStrokeWidth = JXSegmentedViewTool.interpolate(from: itemModel.titleSelectedStrokeWidth, to:itemModel.titleNormalStrokeWidth , percent: percent)
+            } else {
+                // 将要取消选中，StrokeWidth从大到小插值渐变
+                itemModel.titleCurrentStrokeWidth = JXSegmentedViewTool.interpolate(from: itemModel.titleSelectedStrokeWidth, to: itemModel.titleNormalStrokeWidth, percent: percent)
             }
             attriText.addAttributes([NSAttributedString.Key.strokeWidth: itemModel.titleCurrentStrokeWidth], range: NSRange(location: 0, length: attriText.string.count))
             self?.titleLabel.attributedText = attriText
@@ -187,10 +187,10 @@ open class JXSegmentedTitleCell: JXSegmentedBaseCell {
     open func preferredTitleColorAnimateClosure(itemModel: JXSegmentedTitleItemModel) -> JXSegmentedCellSelectedAnimationClosure {
         return {[weak self] (percent) in
             if itemModel.isSelected {
-                //将要选中，textColor从titleNormalColor到titleSelectedColor插值渐变
+                // 将要选中，textColor从titleNormalColor到titleSelectedColor插值渐变
                 itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: itemModel.titleNormalColor, to: itemModel.titleSelectedColor, percent: percent)
-            }else {
-                //将要取消选中，textColor从titleSelectedColor到titleNormalColor插值渐变
+            } else {
+                // 将要取消选中，textColor从titleSelectedColor到titleNormalColor插值渐变
                 itemModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: itemModel.titleSelectedColor, to: itemModel.titleNormalColor, percent: percent)
             }
             self?.titleLabel.textColor = itemModel.titleCurrentColor

--- a/Sources/Title/JXSegmentedTitleDataSource.swift
+++ b/Sources/Title/JXSegmentedTitleDataSource.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
+open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource {
     /// title数组
     open var titles = [String]()
     /// 如果将JXSegmentedView嵌套进UITableView的cell，每次重用的时候，JXSegmentedView进行reloadData时，会重新计算所有的title宽度。所以该应用场景，需要UITableView的cellModel缓存titles的文字宽度，再通过该闭包方法返回给JXSegmentedView。
-    open var widthForTitleClosure: ((String)->(CGFloat))?
+    open var widthForTitleClosure: ((String) -> (CGFloat))?
     /// label的numberOfLines
     open var titleNumberOfLines: Int = 1
     /// title普通状态的textColor
@@ -35,7 +35,6 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
     open var titleSelectedStrokeWidth: CGFloat = -2
     /// title是否使用遮罩过渡
     open var isTitleMaskEnabled: Bool = false
-
 
     open override func preferredItemCount() -> Int {
         return titles.count
@@ -71,7 +70,7 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
             myItemModel.titleCurrentColor = titleSelectedColor
             myItemModel.titleCurrentZoomScale = titleSelectedZoomScale
             myItemModel.titleCurrentStrokeWidth = titleSelectedStrokeWidth
-        }else {
+        } else {
             myItemModel.titleCurrentColor = titleNormalColor
             myItemModel.titleCurrentZoomScale = 1
             myItemModel.titleCurrentStrokeWidth = 0
@@ -81,8 +80,8 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
     open func widthForTitle(_ title: String) -> CGFloat {
         if widthForTitleClosure != nil {
             return widthForTitleClosure!(title)
-        }else {
-            let textWidth = NSString(string: title).boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [.usesFontLeading, .usesLineFragmentOrigin], attributes: [NSAttributedString.Key.font : titleNormalFont], context: nil).size.width
+        } else {
+            let textWidth = NSString(string: title).boundingRect(with: CGSize(width: CGFloat.infinity, height: CGFloat.infinity), options: [.usesFontLeading, .usesLineFragmentOrigin], attributes: [NSAttributedString.Key.font: titleNormalFont], context: nil).size.width
             return CGFloat(ceilf(Float(textWidth)))
         }
     }
@@ -92,13 +91,13 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
         var width = super.preferredSegmentedView(segmentedView, widthForItemAt: index)
         if itemWidth == JXSegmentedViewAutomaticDimension {
             width += (dataSource[index] as! JXSegmentedTitleItemModel).textWidth
-        }else {
+        } else {
             width += itemWidth
         }
         return width
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleCell.self, forCellWithReuseIdentifier: "cell")
     }
@@ -112,14 +111,14 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
         let model = dataSource[index] as! JXSegmentedTitleItemModel
         if isTitleZoomEnabled {
             return model.textWidth*model.titleCurrentZoomScale
-        }else {
+        } else {
             return model.textWidth
         }
     }
 
     open override func refreshItemModel(_ segmentedView: JXSegmentedView, leftItemModel: JXSegmentedBaseItemModel, rightItemModel: JXSegmentedBaseItemModel, percent: CGFloat) {
         super.refreshItemModel(segmentedView, leftItemModel: leftItemModel, rightItemModel: rightItemModel, percent: percent)
-        
+
         guard let leftModel = leftItemModel as? JXSegmentedTitleItemModel, let rightModel = rightItemModel as? JXSegmentedTitleItemModel else {
             return
         }
@@ -136,7 +135,7 @@ open class JXSegmentedTitleDataSource: JXSegmentedBaseDataSource{
 
         if isTitleColorGradientEnabled && isItemTransitionEnabled {
             leftModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: leftModel.titleSelectedColor, to: leftModel.titleNormalColor, percent: percent)
-            rightModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from:rightModel.titleNormalColor , to:rightModel.titleSelectedColor, percent: percent)
+            rightModel.titleCurrentColor = JXSegmentedViewTool.interpolateColor(from: rightModel.titleNormalColor, to: rightModel.titleSelectedColor, percent: percent)
         }
     }
 

--- a/Sources/TitleGradient/JXSegmentedTitleGradientCell.swift
+++ b/Sources/TitleGradient/JXSegmentedTitleGradientCell.swift
@@ -44,7 +44,7 @@ open class JXSegmentedTitleGradientCell: JXSegmentedTitleCell {
             let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (percent) in
                 if myItemModel.isSelected {
                     myItemModel.titleCurrentGradientColors = JXSegmentedViewTool.interpolateColors(from: myItemModel.titleNormalGradientColors, to: myItemModel.titleSelectedGradientColors, percent: percent)
-                }else {
+                } else {
                     myItemModel.titleCurrentGradientColors = JXSegmentedViewTool.interpolateColors(from: myItemModel.titleSelectedGradientColors, to: myItemModel.titleNormalGradientColors, percent: percent)
                 }
                 CATransaction.begin()
@@ -58,7 +58,7 @@ open class JXSegmentedTitleGradientCell: JXSegmentedTitleCell {
             canStartSelectedAnimation = true
             startSelectedAnimationIfNeeded(itemModel: myItemModel, selectedType: selectedType)
             canStartSelectedAnimation = false
-        }else {
+        } else {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             gradientLayer.startPoint = myItemModel.titleGradientStartPoint

--- a/Sources/TitleGradient/JXSegmentedTitleGradientDataSource.swift
+++ b/Sources/TitleGradient/JXSegmentedTitleGradientDataSource.swift
@@ -35,12 +35,12 @@ open class JXSegmentedTitleGradientDataSource: JXSegmentedTitleDataSource {
         itemModel.titleSelectedGradientColors = titleSelectedGradientColors
         if index == selectedIndex {
             itemModel.titleCurrentGradientColors = itemModel.titleSelectedGradientColors
-        }else {
+        } else {
             itemModel.titleCurrentGradientColors = itemModel.titleNormalGradientColors
         }
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleGradientCell.self, forCellWithReuseIdentifier: "cell")
     }

--- a/Sources/TitleImage/JXSegmentedTitleImageCell.swift
+++ b/Sources/TitleImage/JXSegmentedTitleImageCell.swift
@@ -68,7 +68,7 @@ open class JXSegmentedTitleImageCell: JXSegmentedTitleCell {
         imageView.isHidden = false
         if myItemModel.titleImageType == .onlyTitle {
             imageView.isHidden = true
-        }else if myItemModel.titleImageType == .onlyImage {
+        } else if myItemModel.titleImageType == .onlyImage {
             titleLabel.isHidden = true
         }
 
@@ -79,19 +79,19 @@ open class JXSegmentedTitleImageCell: JXSegmentedTitleCell {
             normalImageInfo = myItemModel.selectedImageInfo
         }
 
-        //因为`func reloadData(itemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType)`方法会回调多次，尤其是左右滚动的时候会调用无数次。如果每次都触发图片加载，会非常消耗性能。所以只会在图片发生了变化的时候，才进行图片加载。
+        // 因为`func reloadData(itemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType)`方法会回调多次，尤其是左右滚动的时候会调用无数次。如果每次都触发图片加载，会非常消耗性能。所以只会在图片发生了变化的时候，才进行图片加载。
         if normalImageInfo != nil && normalImageInfo != currentImageInfo {
             currentImageInfo = normalImageInfo
             if myItemModel.loadImageClosure != nil {
                 myItemModel.loadImageClosure!(imageView, normalImageInfo!)
-            }else {
+            } else {
                 imageView.image = UIImage(named: normalImageInfo!)
             }
         }
 
         if myItemModel.isImageZoomEnabled {
             imageView.transform = CGAffineTransform(scaleX: myItemModel.imageCurrentZoomScale, y: myItemModel.imageCurrentZoomScale)
-        }else {
+        } else {
             imageView.transform = .identity
         }
 

--- a/Sources/TitleImage/JXSegmentedTitleImageDataSource.swift
+++ b/Sources/TitleImage/JXSegmentedTitleImageDataSource.swift
@@ -58,7 +58,7 @@ open class JXSegmentedTitleImageDataSource: JXSegmentedTitleDataSource {
         itemModel.titleImageSpacing = titleImageSpacing
         if index == selectedIndex {
             itemModel.imageCurrentZoomScale = itemModel.imageSelectedZoomScale
-        }else {
+        } else {
             itemModel.imageCurrentZoomScale = itemModel.imageNormalZoomScale
         }
     }
@@ -95,7 +95,7 @@ open class JXSegmentedTitleImageDataSource: JXSegmentedTitleDataSource {
         return width
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleImageCell.self, forCellWithReuseIdentifier: "cell")
     }

--- a/Sources/TitleOrImage/JXSegmentedTitleOrImageCell.swift
+++ b/Sources/TitleOrImage/JXSegmentedTitleOrImageCell.swift
@@ -41,21 +41,21 @@ open class JXSegmentedTitleOrImageCell: JXSegmentedTitleCell {
         if myItemModel.isSelected && myItemModel.selectedImageInfo != nil {
             titleLabel.isHidden = true
             imageView.isHidden = false
-        }else {
+        } else {
             titleLabel.isHidden = false
             imageView.isHidden = true
         }
 
         imageView.bounds = CGRect(x: 0, y: 0, width: myItemModel.imageSize.width, height: myItemModel.imageSize.height)
 
-        //因为`func reloadData(itemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType)`方法会回调多次，尤其是左右滚动的时候会调用无数次。如果每次都触发图片加载，会非常消耗性能。所以只会在图片发生了变化的时候，才进行图片加载。
+        // 因为`func reloadData(itemModel: JXSegmentedBaseItemModel, selectedType: JXSegmentedViewItemSelectedType)`方法会回调多次，尤其是左右滚动的时候会调用无数次。如果每次都触发图片加载，会非常消耗性能。所以只会在图片发生了变化的时候，才进行图片加载。
         if myItemModel.isSelected &&
             myItemModel.selectedImageInfo != nil &&
             myItemModel.selectedImageInfo != currentImageInfo {
             currentImageInfo = myItemModel.selectedImageInfo
             if myItemModel.loadImageClosure != nil {
                 myItemModel.loadImageClosure!(imageView, myItemModel.selectedImageInfo!)
-            }else {
+            } else {
                 imageView.image = UIImage(named: myItemModel.selectedImageInfo!)
             }
         }
@@ -68,22 +68,22 @@ open class JXSegmentedTitleOrImageCell: JXSegmentedTitleCell {
             return super.preferredTitleZoomAnimateClosure(itemModel: itemModel, baseScale: baseScale)
         }
         if myItemModel.selectedImageInfo == nil && myItemModel.isSelected {
-            //当前item没有选中图片且是将要选中的时候才做动画
+            // 当前item没有选中图片且是将要选中的时候才做动画
             return super.preferredTitleZoomAnimateClosure(itemModel: itemModel, baseScale: baseScale)
-        }else {
-            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (percent) in
+        } else {
+            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (_) in
                 if itemModel.isSelected {
-                    //将要选中
+                    // 将要选中
                     itemModel.titleCurrentZoomScale = itemModel.titleSelectedZoomScale
-                }else {
-                    //将要取消选中
+                } else {
+                    // 将要取消选中
                     itemModel.titleCurrentZoomScale = itemModel.titleNormalZoomScale
                 }
                 let currentTransform = CGAffineTransform(scaleX: baseScale*itemModel.titleCurrentZoomScale, y: baseScale*itemModel.titleCurrentZoomScale)
                 self?.titleLabel.transform = currentTransform
                 self?.maskTitleLabel.transform = currentTransform
             }
-            //手动调用closure，更新到最新状态
+            // 手动调用closure，更新到最新状态
             closure(0)
             return closure
         }
@@ -94,21 +94,21 @@ open class JXSegmentedTitleOrImageCell: JXSegmentedTitleCell {
             return super.preferredTitleStrokeWidthAnimateClosure(itemModel: itemModel, attriText: attriText)
         }
         if myItemModel.selectedImageInfo == nil && myItemModel.isSelected {
-            //当前item没有选中图片且是将要选中的时候才做动画
+            // 当前item没有选中图片且是将要选中的时候才做动画
             return super.preferredTitleStrokeWidthAnimateClosure(itemModel: itemModel, attriText: attriText)
-        }else {
-            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (percent) in
+        } else {
+            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (_) in
                 if itemModel.isSelected {
-                    //将要选中
+                    // 将要选中
                     itemModel.titleCurrentStrokeWidth = itemModel.titleSelectedStrokeWidth
-                }else {
-                    //将要取消选中
+                } else {
+                    // 将要取消选中
                     itemModel.titleCurrentStrokeWidth = itemModel.titleNormalStrokeWidth
                 }
                 attriText.addAttributes([NSAttributedString.Key.strokeWidth: itemModel.titleCurrentStrokeWidth], range: NSRange(location: 0, length: attriText.string.count))
                 self?.titleLabel.attributedText = attriText
             }
-            //手动调用closure，更新到最新状态
+            // 手动调用closure，更新到最新状态
             closure(0)
             return closure
         }
@@ -119,23 +119,23 @@ open class JXSegmentedTitleOrImageCell: JXSegmentedTitleCell {
             return super.preferredTitleColorAnimateClosure(itemModel: itemModel)
         }
         if myItemModel.selectedImageInfo == nil && myItemModel.isSelected {
-            //当前item没有选中图片且是将要选中的时候才做动画
+            // 当前item没有选中图片且是将要选中的时候才做动画
             return super.preferredTitleColorAnimateClosure(itemModel: itemModel)
-        }else {
-            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (percent) in
+        } else {
+            let closure: JXSegmentedCellSelectedAnimationClosure = {[weak self] (_) in
                 if itemModel.isSelected {
-                    //将要选中
+                    // 将要选中
                     itemModel.titleCurrentColor = itemModel.titleSelectedColor
-                }else {
-                    //将要取消选中
+                } else {
+                    // 将要取消选中
                     itemModel.titleCurrentColor = itemModel.titleNormalColor
                 }
                 self?.titleLabel.textColor = itemModel.titleCurrentColor
             }
-            //手动调用closure，更新到最新状态
+            // 手动调用closure，更新到最新状态
             closure(0)
             return closure
         }
     }
-    
+
 }

--- a/Sources/TitleOrImage/JXSegmentedTitleOrImageDataSource.swift
+++ b/Sources/TitleOrImage/JXSegmentedTitleOrImageDataSource.swift
@@ -38,7 +38,7 @@ open class JXSegmentedTitleOrImageDataSource: JXSegmentedTitleDataSource {
         itemModel.imageSize = imageSize
     }
 
-    //MARK: - JXSegmentedViewDataSource
+    // MARK: - JXSegmentedViewDataSource
     open override func registerCellClass(in segmentedView: JXSegmentedView) {
         segmentedView.collectionView.register(JXSegmentedTitleOrImageCell.self, forCellWithReuseIdentifier: "cell")
     }


### PR DESCRIPTION
在开启BUILD_LIBRARY_FOR_DISTRIBUTION的情况下无法extension写objc的方法；
鉴于有OC版本的实现，这里可以去掉协议声明中的@objc；

注意：
由于改变了方法的返回值类型：
 - Bool -> Bool?
 - AnyClass -> AnyClass?
 且添加了默认实现以实现optional，所以这次提交是个破坏性的提交，与**历史版本有兼容问题**。