### PR TITLE
解決 listDidAppear 觸發不正確頁面問題

### DIFF
--- a/Sources/Common/JXSegmentedListContainerView.swift
+++ b/Sources/Common/JXSegmentedListContainerView.swift
@@ -428,7 +428,7 @@ extension JXSegmentedListContainerView: UICollectionViewDataSource, UICollection
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard scrollView.isTracking || scrollView.isDragging else {
+        guard scrollView.isTracking || scrollView.isDragging || scrollView.isDecelerating else {
             return
         }
         let percent = scrollView.contentOffset.x/scrollView.bounds.size.width


### PR DESCRIPTION
托動頁面 percent 超過 0.5，放掉頁面(直接將手指拿起 不往右滑動) 會無法觸發正確頁面的 listDidAppear