### PR TITLE
build: fix the compilation error with xcode 16

### DIFF
--- a/Sources/Indicator/JXSegmentedIndicatorGradientView.swift
+++ b/Sources/Indicator/JXSegmentedIndicatorGradientView.swift
@@ -118,7 +118,11 @@ open class JXSegmentedIndicatorGradientView: JXSegmentedIndicatorBaseView {
             animation.fromValue = gradientMaskLayer.path
             animation.toValue = path.cgPath
             animation.duration = scrollAnimationDuration
-            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
+            if #available(iOS 12.0, *) {
+                animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            } else {
+                animation.timingFunction = CAMediaTimingFunction(controlPoints: 0.0, 0.0, 0.58, 1.0)
+            }
             gradientMaskLayer.add(animation, forKey: "path")
             gradientMaskLayer.path = path.cgPath
         }else {


### PR DESCRIPTION
Starting with iOS18, CAMediatTimingFunctionName is marked as iOS12 only. To support iOS below 12 we need to construct the CAMediaTimingFunction with explicit control points.